### PR TITLE
outfile.fetch in paired output writer. 

### DIFF
--- a/umi_tools/dedup.py
+++ b/umi_tools/dedup.py
@@ -306,7 +306,7 @@ class TwoPassPairWriter:
 
         found = 0
         for name, chrom, pos in self.read1s:
-            for read in self.outfile.fetch(start=pos, end=pos+1, tid=chrom):
+            for read in self.infile.fetch(start=pos, end=pos+1, tid=chrom):
                 if (read.query_name, read.pos) == (name, pos):
                     self.outfile.write(read)
                     found += 1


### PR DESCRIPTION
Paired writer was calling fetch on outfile rather than infile to find unmatched pairs cf issue #50.

Can't think what I was thinking when I wrote this. Clearly the first person to run a paired file that had paired reads in it (or mates on a different chromosome) was going to trigger this error. 
