### PR TITLE
Tom smith cgat patch setuptools

### DIFF
--- a/ez_setup.py
+++ b/ez_setup.py
@@ -157,7 +157,6 @@ def use_setuptools(
 
     try:
         import pkg_resources
-        print "`\n\n\n\n\n\n\nsetuptools>=" + version
         pkg_resources.require("setuptools>=" + version)
         # a suitable version is already installed
         return

--- a/ez_setup.py
+++ b/ez_setup.py
@@ -157,6 +157,7 @@ def use_setuptools(
 
     try:
         import pkg_resources
+        print "`\n\n\n\n\n\n\nsetuptools>=" + version
         pkg_resources.require("setuptools>=" + version)
         # a suitable version is already installed
         return

--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,8 @@ import sys
 import os
 import glob
 
-from ez_setup import use_setuptools
-use_setuptools()
+#from ez_setup import use_setuptools
+#use_setuptools()
 import setuptools
 
 from setuptools import setup, find_packages, Extension

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import os
 import glob
 
 from ez_setup import use_setuptools
-use_setuptools("1.1")
+use_setuptools("10.0")
 import setuptools
 
 from setuptools import setup, find_packages, Extension

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import os
 import glob
 
 from ez_setup import use_setuptools
-use_setuptools()
+use_setuptools("1.1")
 import setuptools
 
 from setuptools import setup, find_packages, Extension

--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,8 @@ import sys
 import os
 import glob
 
-#from ez_setup import use_setuptools
-#use_setuptools()
+from ez_setup import use_setuptools
+use_setuptools()
 import setuptools
 
 from setuptools import setup, find_packages, Extension


### PR DESCRIPTION
@IanSudbery I've hardcoded a minimum requirement for setuptools in the use_setuptools() function. previously we didn't specify a minimum version so it defaults to the latest version. 

I think this is the most likely explanation for the odd installation errors where it appears to reinstall setuptools even after installing all the requirements. This was stopping the conda build working for me. However, this also suggests the easy install solution might not work when required?