### PR TITLE
Ts replace comprehension

### DIFF
--- a/umi_tools/dedup.py
+++ b/umi_tools/dedup.py
@@ -561,6 +561,9 @@ def main(argv=None):
 
         # TS - see comment above regarding missing values
         agg_df = agg_df.fillna(0).astype(int)
+
+        agg_df.index = [x.decode() for x in agg_df.index]
+        agg_df.index.name = 'UMI'
         agg_df.to_csv(options.stats + "_per_umi.tsv", sep="\t")
 
         # bin distances into integer bins

--- a/umi_tools/group.py
+++ b/umi_tools/group.py
@@ -407,9 +407,9 @@ def main(argv=None):
                         mapping_outfile.write("%s\n" % "\t".join(map(str, (
                             read.query_name, read.reference_name,
                             umi_methods.get_read_position(read, options.soft)[1],
-                            umi_methods.get_umi(read, options.umi_sep),
+                            umi_methods.get_umi(read, options.umi_sep).decode(),
                             counts[top_umi],
-                            top_umi,
+                            top_umi.decode(),
                             group_count,
                             unique_id))))
 

--- a/umi_tools/network.py
+++ b/umi_tools/network.py
@@ -179,17 +179,21 @@ class ReadClusterer:
     def _get_connected_components_adjacency(self, umis, graph, counts):
         ''' find the connected UMIs within an adjacency dictionary'''
 
-        if len(graph) < 10000:
-            self.search = breadth_first_search_recursive
-        else:
-            self.search = breadth_first_search
+        # TS: TO DO: Work out why recursive function does lead to same
+        # final output. Then uncomment below
+
+        #if len(graph) < 10000:
+        #    self.search = breadth_first_search_recursive
+        #else:
+        #    self.search = breadth_first_search
 
         found = set()
         components = list()
 
         for node in sorted(graph, key=lambda x: counts[x], reverse=True):
             if node not in found:
-                component = self.search(node, graph)
+                #component = self.search(node, graph)
+                component = breadth_first_search(node, graph)
                 found.update(component)
                 components.append(component)
 

--- a/umi_tools/network.py
+++ b/umi_tools/network.py
@@ -184,13 +184,13 @@ class ReadClusterer:
         else:
             self.search = breadth_first_search
 
-        found = list()
+        found = set()
         components = list()
 
         for node in sorted(graph, key=lambda x: counts[x], reverse=True):
             if node not in found:
                 component = self.search(node, graph)
-                found.extend(component)
+                found.update(component)
                 components.append(component)
 
         return components

--- a/umi_tools/network.py
+++ b/umi_tools/network.py
@@ -124,7 +124,7 @@ class ReadClusterer:
     def _get_adj_list_adjacency(self, umis, counts, threshold):
         ''' identify all umis within hamming distance threshold'''
 
-        adj_list = collections.defaultdict(list)
+        adj_list = {umi: [] for umi in umis}
         for umi1, umi2 in itertools.combinations(umis, 2):
             if edit_distance(umi1, umi2) <= threshold:
                 adj_list[umi1].append(umi2)
@@ -132,12 +132,11 @@ class ReadClusterer:
 
         return adj_list
 
-
     def _get_adj_list_directional(self, umis, counts, threshold=1):
         ''' identify all umis within the hamming distance threshold
         and where the counts of the first umi is > (2 * second umi counts)-1'''
 
-        adj_list = collections.defaultdict(list)
+        adj_list = {umi: [] for umi in umis}
         for umi1, umi2 in itertools.combinations(umis, 2):
             if edit_distance(umi1, umi2) <= threshold:
                 if counts[umi1] >= (counts[umi2]*2)-1:
@@ -159,7 +158,7 @@ class ReadClusterer:
         found = list()
         components = list()
 
-        for node in sorted(umis, key=lambda x: counts[x], reverse=True):
+        for node in sorted(graph, key=lambda x: counts[x], reverse=True):
             if node not in found:
                 component = breadth_first_search(node, graph)
                 found.extend(component)

--- a/umi_tools/umi_methods.py
+++ b/umi_tools/umi_methods.py
@@ -32,7 +32,7 @@ except:
 
 def get_umi(read, sep="_"):
     try:
-        return read.qname.split(sep)[-1]
+        return read.qname.split(sep)[-1].encode('utf-8')
     except IndexError:
         raise ValueError("Could not extract UMI from read, please"
                          "check UMI is encoded in the read name"
@@ -44,7 +44,7 @@ def get_average_umi_distance(umis):
     if len(umis) == 1:
         return -1
 
-    dists = [edit_distance(x.encode('utf-8'), y.encode('utf-8')) for
+    dists = [edit_distance(x, y) for
              x, y in itertools.combinations(umis, 2)]
     return float(sum(dists))/(len(dists))
 


### PR DESCRIPTION
This contains most of the changes implemented to improved run-time. See #69 for a full discussion of the changes. 

The recursive search was causing test failure due to changes in output order for the _group_cluster_ test. On further inspection, the output from _dedup_ when run on a high depth BAM is also not consistent between the `breath_first_search` and `breath_first_search_recursive` functions. 

@IanSudbery I can't see why the recursive search should modify the output but I'll try and look into this shortly. For the time being, the recursive search has been commented out.