### PR TITLE
updates gettag method to support 10X UMI tag encoding

### DIFF
--- a/umi_tools/umi_methods.py
+++ b/umi_tools/umi_methods.py
@@ -45,7 +45,9 @@ def get_umi_tag(read, tag='RX'):
     ''' extract the umi from the specified tag '''
 
     try:
-        return read.get_tag(tag).encode('utf-8')
+        # 10X pipelines append a 'GEM' tag to the UMI, e.g
+        # AGAGSGATAGATA-1
+        return read.get_tag(tag).encode('utf-8').split("-")[0]
     except IndexError:
         raise ValueError(
             "Could not extract UMI from the read tags, please"


### PR DESCRIPTION
10X long ranger pipelines add a tag with the UMI (BX) but this is also appended with the 'GEM' group, e.g
AGAGAGAGTA-1

Quoting from: https://support.10xgenomics.com/genome-exome/software/pipelines/latest/output/bam

_'This number denotes what we call a GEM group, and is used to virtualize barcodes in order to achieve a higher effective barcode diversity when combining samples generated from separate GEM chip channel runs. Normally, this number will be "1" across all barcodes when analyzing a sample generated from a single GEM chip channel. It can either be left in place and treated as part of a unique barcode identifier, or explicitly parsed out to leave only the barcode sequence itself.'_