### PR TITLE
Speed up paired end umi deduping

### DIFF
--- a/umi_tools/umi_methods.py
+++ b/umi_tools/umi_methods.py
@@ -115,8 +115,7 @@ class TwoPassPairWriter:
         if self.chrom is not None:
             U.debug("Dumping %i mates for contig %s" % (
                 len(self.read1s), self.chrom))
-        
-        
+
         for read in self.infile.fetch(reference=self.chrom, multiple_iterators=True):
             if any((read.is_unmapped, read.mate_is_unmapped, read.is_read1)):
                 continue

--- a/umi_tools/umi_methods.py
+++ b/umi_tools/umi_methods.py
@@ -99,7 +99,7 @@ class TwoPassPairWriter:
             self.write_mates()
             self.chrom = read.reference_name
 
-        key = read.query_name, read.reference_name, read.next_reference_start
+        key = read.query_name, read.next_reference_name, read.next_reference_start
         self.read1s.add(key)
 
         if self.read2tags is not None:

--- a/umi_tools/umi_methods.py
+++ b/umi_tools/umi_methods.py
@@ -95,11 +95,11 @@ class TwoPassPairWriter:
             self.outfile.write(read)
             return
 
-        if not self.chrom == read.reference_id:
+        if not self.chrom == read.reference_name:
             self.write_mates()
-            self.chrom = read.reference_id
+            self.chrom = read.reference_name
 
-        key = read.query_name, read.next_reference_id, read.next_reference_start
+        key = read.query_name, read.reference_name, read.next_reference_start
         self.read1s.add(key)
 
         if self.read2tags is not None:
@@ -112,16 +112,16 @@ class TwoPassPairWriter:
     def write_mates(self):
         '''Scan the current chromosome for matches to any of the reads stored
         in the read1s buffer'''
-
         if self.chrom is not None:
             U.debug("Dumping %i mates for contig %s" % (
-                len(self.read1s), self.infile.get_reference_name(self.chrom)))
-
-        for read in self.infile.fetch(tid=self.chrom, multiple_iterators=True):
+                len(self.read1s), self.chrom))
+        
+        
+        for read in self.infile.fetch(reference=self.chrom, multiple_iterators=True):
             if any((read.is_unmapped, read.mate_is_unmapped, read.is_read1)):
                 continue
 
-            key = read.query_name, read.reference_id, read.reference_start
+            key = read.query_name, read.reference_name, read.reference_start
             if key in self.read1s:
                 if self.read2tags is not None:
                     unique_id, umi = self.read2tags[key]


### PR DESCRIPTION
There is currently a bug with tid not actually fetching just the chromosome of interest in pysam.  This slows down the deduping for files with large amounts of contigs.  At least on my computer if you fetch via tid, all the reads get fetched (issue https://github.com/pysam-developers/pysam/issues/415).  While we wait for that bug to get fixed, I fixed this issue by removing tids from the code using the chromosome name instead.

This fixes issue https://github.com/CGATOxford/UMI-tools/issues/93 that I created.

Is there any testing or QC you'd like to me run before accepting this, let me know, I haven't done anything yet.  