### PR TITLE
Do not cache read for mate output if mate is unmapped.

### DIFF
--- a/umi_tools/umi_methods.py
+++ b/umi_tools/umi_methods.py
@@ -91,7 +91,7 @@ class TwoPassPairWriter:
         for mates. Write the read to outfile and save the identity for paired
         end retrieval'''
 
-        if unmapped:
+        if unmapped or read.mate_is_unmapped:
             self.outfile.write(read)
             return
 


### PR DESCRIPTION
pysam.AlignedSegment.next_reference_name throws ValueError if the mate is unmapped.

If `group` is run with `--output-unmapped` then if read1 is mapped, but read2 is not, TwoPassWriter throws an error because of this. 

This fix skips trying to store the mate details for delayed outputting if the mate is unmapped. In this case the mate is output independently anyway. 