### PR TITLE
py3 transparent gzipped output

### DIFF
--- a/umi_tools/Utilities.py
+++ b/umi_tools/Utilities.py
@@ -499,7 +499,16 @@ def openFile(filename, mode="r", create_dir=False):
             os.makedirs(dirname)
 
     if ext.lower() in (".gz", ".z"):
-        return gzip.open(filename, mode)
+        if sys.version_info.major >= 3:
+            if mode == "r":
+                return gzip.open(filename, 'rt', encoding="ascii")
+            elif mode == "w":
+                return gzip.open(filename, 'wt', encoding="ascii")
+            else:
+                raise NotImplementedError(
+                    "mode '{}' not implemented".format(mode))
+        else:
+            return gzip.open(filename, mode)
     else:
         return open(filename, mode)
 


### PR DESCRIPTION
Python3 requires an encoding and text mode to be specified to be able to output strings to a zip file. This was breaking the ability output to a zip file from extract if the user was using python 3.X.

This should really have tests, but I don't have time to implement right now.
