### PR TITLE
{ts} debug per gene

### DIFF
--- a/umi_tools/dedup.py
+++ b/umi_tools/dedup.py
@@ -231,7 +231,9 @@ very long (>14bp)
 
 --skip-tags-regex (string)
       Used in conjunction with the --gene-tag option. Skip any reads
-      where the gene tag matches this regex. Defualt = "Unassigned\s*"
+      where the gene tag matches this regex.
+      Defualt matches anything which starts with "__" or "Unassigned":
+      ("^[__|Unassigned]")
 
 -i, --in-sam/-o, --out-sam
       By default, inputs are assumed to be in BAM format and output are output
@@ -437,7 +439,7 @@ def main(argv=None):
                       type="string",
                       help=("Used with --gene-tag. "
                             "Ignore reads where the gene-tag matches this regex"),
-                      default="Unassigned\s*")
+                      default="^[__|Unassigned]")
 
     # add common options (-h/--help, ...) and parse command line
     (options, args) = U.Start(parser, argv=argv)

--- a/umi_tools/umi_methods.py
+++ b/umi_tools/umi_methods.py
@@ -14,6 +14,7 @@ import collections
 import random
 import numpy as np
 import pysam
+import re
 
 # required to make iteritems python2 and python3 compatible
 from future.utils import iteritems
@@ -216,7 +217,7 @@ def metafetcher(bamfile, metacontig2contig):
 def get_bundles(inreads, ignore_umi=False, subset=None,
                 quality_threshold=0, paired=False, spliced=False,
                 soft_clip_threshold=0, per_contig=False,
-                per_gene=False, gene_tag=None,
+                per_gene=False, gene_tag=None, skip_regex=None,
                 whole_contig=False, read_length=False,
                 detection_method="MAPQ", umi_getter=None,
                 all_reads=False, return_unmapped=False):
@@ -295,6 +296,8 @@ def get_bundles(inreads, ignore_umi=False, subset=None,
             elif gene_tag:
                 pos = read.get_tag(gene_tag)
                 key = pos
+                if re.search(skip_regex, pos):
+                    continue
 
             if not pos == last_chr:
 


### PR DESCRIPTION
The --gene-tag option previously assumed all gene tags were gene names. featureCounts and HTSeq both use the same tag for the gene as the assignment status. These commits introduces the --gene-tags-skip option to ensure unassigned reads do not cause bundles to be yielded prematurely and unassigned reads are not outputted. 