### PR TITLE
Update deduplicated_edit_distance.tsv's description

### DIFF
--- a/QUICK_START.md
+++ b/QUICK_START.md
@@ -191,7 +191,7 @@ in the overall usage of particular UMI sequences). The last two
 columns the same, but for the naive `unique` deduplication method
 where every UMI is assumed to represent an independent molecule in the
 biological sample. Looking at the third row, we see that there are
-11167 positions where the average edit distance between
+1167 positions where the average edit distance between
 UMIs is 1, whereas in the random null (in the final column) we would
 only expect to see 33 such bases.
 


### PR DESCRIPTION
From the context of Step5 Deduplication, in deduplicated_edit_distance.tsv file's third line, the positions where the average edit distance between UMIs is 1 should be '1167', not '11167'.