### PR TITLE
added import at start of umi_tools

### DIFF
--- a/umi_tools/umi_tools.py
+++ b/umi_tools/umi_tools.py
@@ -24,6 +24,8 @@ To use a specific tool, type::
 import os
 import sys
 import imp
+import matplotlib
+matplotlib.use('Agg')
 
 
 def main(argv=None):


### PR DESCRIPTION
umi_tools crashes when running on a system without a graphical interface.

```  File "python3.6/tkinter/__init__.py", line 2017, in __init__
    self.tk = _tkinter.create(screenName, baseName, className, interactive, wantobjects, useTk, sync, use)
_tkinter.TclError: no display name and no $DISPLAY environment variable
```

small fix that worked on my cluster