### PR TITLE
{ts} add expect cells option

### DIFF
--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -68,12 +68,19 @@ whitelist_indrop:
       references: [indrop_whitelist.tsv]
       options: whitelist --extract-method=regex --bc-pattern="(?P<cell_1>.{8,12})(?P<discard_2>GAGTGATTGCTTGTGACGCCTT)(?P<cell_3>.{8})(?P<umi_1>.{6})T{3}.*" -L test.log 
 
-whitelist_indrop_user:
+whitelist_indrop_set_cell:
       skip_python:
       stdin: indrop.fastq.1.gz
       outputs: [stdout]
       references: [indrop_whitelist_user.tsv]
       options: whitelist --extract-method=regex --bc-pattern="(?P<cell_1>.{8,12})(?P<discard_2>GAGTGATTGCTTGTGACGCCTT)(?P<cell_3>.{8})(?P<umi_1>.{6})T{3}.*" -L test.log --set-cell-number=607
+
+whitelist_indrop_expect_cells:
+      skip_python:
+      stdin: indrop.fastq.1.gz
+      outputs: [stdout]
+      references: [indrop_whitelist_user.tsv]
+      options: whitelist --extract-method=regex --bc-pattern="(?P<cell_1>.{8,12})(?P<discard_2>GAGTGATTGCTTGTGACGCCTT)(?P<cell_3>.{8})(?P<umi_1>.{6})T{3}.*" -L test.log --expect-cells=1000
 
 whitelist_indrop_fuzzy:
       stdin: indrop.fastq.1.gz

--- a/umi_tools/Utilities.py
+++ b/umi_tools/Utilities.py
@@ -1145,8 +1145,97 @@ def getTempFilename(dir=None, shared=False, suffix=""):
     return tmpfile.name
 
 # this is the generic docstring we want to add to the documentation
-# for group/dedup/count
-GENERIC_DOCSTRING = '''
+# for whitelist/extract
+GENERIC_DOCSTRING_WE = '''
+Barcode extraction
+------------------
+
+There are two methods enabled to extract the umi barocode (+/- cell
+barcode). For both methods, the patterns should be provided using the
+--bc-pattern and --bc-pattern options. The method is specified using
+the --extract-method option
+
+-'string':
+       This should be used where the barcodes are always in the same
+       place in the read.
+
+       - N = UMI position (required)
+       - C = cell barcode position (optional)
+       - X = sample position (optional)
+
+       Bases with Ns and Cs will be extracted and added to the read
+       name. The corresponding sequence qualities will be removed from
+       the read. Bases with an X will be reattached to the read.
+
+       E.g. If the pattern is NNNNCC,
+       Then the read:
+       @HISEQ:87:00000000 read1
+       AAGGTTGCTGATTGGATGGGCTAG
+       DA1AEBFGGCG01DFH00B1FF0B
+       +
+       will become:
+       @HISEQ:87:00000000_TT_AAGG read1
+       GCTGATTGGATGGGCTAG
+       1AFGGCG01DFH00B1FF0B
+       +
+
+       where 'TT' is the cell barcode and 'AAGG' is the UMI.
+
+-'regex'
+       This method allows for more flexible barcode extraction and
+       should be used where the cell barcodes are variable in
+       length. Alternatively, the regex option can also be used to
+       filter out reads which do not contain an expected adapter
+       sequence.
+
+       The expected groups in the regex are:
+
+       umi_n = UMI positions, where n can be any value (required)
+       cell_n = cell barcode positions, where n can be any value (optional)
+       discard_n = positions to discard, where n can be any value (optional)
+
+       UMI positions and cell barcode positions will be extrated and
+       added to the read name. The corresponding sequence qualities
+       will be removed from the read. Discard bases and the
+       corresponding quality scores will be removed from the read. All
+       bases matched by other groups or componentts of the regex will
+       reattached to the read sequence
+
+       For example, the following regex can be used to extract reads
+       from the Klein et al inDrop data:
+
+       (?P<cell_1>.{8,12})(?P<discard_1>GAGTGATTGCTTGTGACGCCTT)(?P<cell_2>.{8})(?P<umi_1>.{6})T{3}.*
+
+       Where only reads with a 3' T-tail and GAGTGATTGCTTGTGACGCCTT in
+       the correct position to yield two cell barcodes of 8-12 and 8bp
+       respectively, and a 6bp UMI will be retained.
+
+       You can also specify fuzzy matching to allow errors. For example if
+       the discard group above was specified as below this would enable
+       matches with up to 2 errors in the discard_1 group.
+
+       (?P<discard_1>GAGTGATTGCTTGTGACGCCTT{s<=2})
+
+       Note that all UMIs must be the same length for downstream
+       processing with dedup, group or count commands
+
+
+additional whitelist/extract options
+-------------------------
+
+--3prime
+       By default the barcode is assumed to be on the 5' end of the
+       read, but use this option to sepecify that it is on the 3' end
+       instead. This option only works with --extact-method=string
+       since 3' encoding can be specified explicitly with a regex, e.g
+       ".*(?P<umi_1>.{5})$"
+
+'''
+
+
+# this is the generic docstring we want to add to the documentation
+# for group/dedup/count/count_tab
+GENERIC_DOCSTRING_GDC = '''
 It is assumed that the FASTQ files were processed with extract_umi.py
 before mapping and thus the UMI is the last word of the read name. e.g:
 

--- a/umi_tools/count.py
+++ b/umi_tools/count.py
@@ -45,7 +45,7 @@ except ImportError:
 
 
 # add the generic docstring text
-__doc__ = __doc__ + U.GENERIC_DOCSTRING
+__doc__ = __doc__ + U.GENERIC_DOCSTRING_GDC
 
 
 def main(argv=None):

--- a/umi_tools/count_tab.py
+++ b/umi_tools/count_tab.py
@@ -58,7 +58,7 @@ except ImportError:
     import umi_methods
 
 # add the generic docstring text
-__doc__ = __doc__ + U.GENERIC_DOCSTRING
+__doc__ = __doc__ + U.GENERIC_DOCSTRING_GDC
 
 
 def main(argv=None):

--- a/umi_tools/dedup.py
+++ b/umi_tools/dedup.py
@@ -80,7 +80,7 @@ except ImportError:
 
 
 # add the generic docstring text
-__doc__ = __doc__ + U.GENERIC_DOCSTRING
+__doc__ = __doc__ + U.GENERIC_DOCSTRING_GDC
 __doc__ = __doc__ + U.GROUP_DEDUP_GENERIC_OPTIONS
 
 

--- a/umi_tools/extract.py
+++ b/umi_tools/extract.py
@@ -18,79 +18,6 @@ for an explanation for how to encode the barcode pattern(s) to
 specficy the position of the UMI +/- cell barcode.
 
 
-Barcode extraction
-------------------
-
-There are two methods enabled to extract the umi barocode (+/- cell
-barcode). For both methods, the patterns should be provided using the
---bc-pattern and --bc-pattern options. The method is specified using
-the --extract-method option
-
--'string':
-       This should be used where the barcodes are always in the same
-       place in the read.
-
-       - N = UMI position (required)
-       - C = cell barcode position (optional)
-       - X = sample position (optional)
-
-       Bases with Ns and Cs will be extracted and added to the read
-       name. The corresponding sequence qualities will be removed from
-       the read. Bases with an X will be reattached to the read.
-
-       E.g. If the pattern is NNNNCC,
-       Then the read:
-       @HISEQ:87:00000000 read1
-       AAGGTTGCTGATTGGATGGGCTAG
-       DA1AEBFGGCG01DFH00B1FF0B
-       +
-       will become:
-       @HISEQ:87:00000000_TT_AAGG read1
-       GCTGATTGGATGGGCTAG
-       1AFGGCG01DFH00B1FF0B
-       +
-
-       where 'TT' is the cell barcode and 'AAGG' is the UMI.
-
--'regex'
-       This method allows for more flexible barcode extraction and
-       should be used where the cell barcodes are variable in
-       length. Alternatively, the regex option can also be used to
-       filter out reads which do not contain an expected adapter
-       sequence.
-
-       The expected groups in the regex are:
-
-       umi_n = UMI positions, where n can be any value (required)
-       cell_n = cell barcode positions, where n can be any value (optional)
-       discard_n = positions to discard, where n can be any value (optional)
-
-       UMI positions and cell barcode positions will be extrated and
-       added to the read name. The corresponding sequence qualities
-       will be removed from the read. Discard bases and the
-       corresponding quality scores will be removed from the read. All
-       bases matched by other groups or componentts of the regex will
-       reattached to the read sequence
-
-       For example, the following regex can be used to extract reads
-       from the Klein et al inDrop data:
-
-       (?P<cell_1>.{8,12})(?P<discard_1>GAGTGATTGCTTGTGACGCCTT)(?P<cell_2>.{8})(?P<umi_1>.{6})T{3}.*
-
-       Where only reads with a 3' T-tail and GAGTGATTGCTTGTGACGCCTT in
-       the correct position to yield two cell barcodes of 8-12 and 8bp
-       respectively, and a 6bp UMI will be retained.
-
-       You can also specify fuzzy matching to allow errors. For example if
-       the discard group above was specified as below this would enable
-       matches with up to 2 errors in the discard_1 group.
-
-       (?P<discard_1>GAGTGATTGCTTGTGACGCCTT{s<=2})
-
-       Note that all UMIs must be the same length for downstream
-       processing with dedup, group or count commands
-
-
 Filtering and correcting cell barcodes
 --------------------------------------
 
@@ -121,18 +48,6 @@ option is not used, this column will be ignored. Any additional columns
 in the whitelist input, such as the counts columns from the output of
 umi_tools whitelist, will be ignored.
 
-Options
--------
-
---3prime
-       By default the barcode is assumed to be on the 5' end of the
-       read, but use this option to sepecify that it is on the 3' end
-       instead. This option only works with --extact-method=string
-       since 3' encoding can be specified explicitly with a regex, e.g
-       ".*(?P<umi_1>.{5})$"
-
--L (string, filename)
-       Specify a log file to retain logging information and final statistics
 
 Usage:
 ------
@@ -156,9 +71,6 @@ Using regex and filtering against a whitelist of cell barcodes:
         umi_tools extract --extract-method=regex --filter-cell-barcode
         --bc-pattern=[REGEX] --whitlist=[WHITELIST_TSV]
         -L extract.log [OPTIONS]
-
-Command line options
---------------------
 
 '''
 import sys
@@ -192,6 +104,9 @@ try:
     import umi_tools.umi_methods as umi_methods
 except ImportError:
     import umi_methods
+
+# add the generic docstring text
+__doc__ = __doc__ + U.GENERIC_DOCSTRING_WE
 
 
 def main(argv=None):

--- a/umi_tools/group.py
+++ b/umi_tools/group.py
@@ -103,7 +103,7 @@ except ImportError:
     import umi_methods
 
 # add the generic docstring text
-__doc__ = __doc__ + U.GENERIC_DOCSTRING
+__doc__ = __doc__ + U.GENERIC_DOCSTRING_GDC
 __doc__ = __doc__ + U.GROUP_DEDUP_GENERIC_OPTIONS
 
 

--- a/umi_tools/umi_methods.py
+++ b/umi_tools/umi_methods.py
@@ -191,8 +191,8 @@ def getKneeEstimate(cell_barcode_counts,
                     # the last threshold here prevents selecting a local
                     # minima with v.low counts
                     if (passing_threshold > expect_cells * 0.1 and
-                        passing_threshold <= expect_cells and 
-                        poss_local_min >= 0.05 * xx_values): 
+                        passing_threshold <= expect_cells and
+                        poss_local_min >= 0.05 * xx_values):
                         local_min = poss_local_min
 
                 else:  # we have no prior expectation

--- a/umi_tools/umi_methods.py
+++ b/umi_tools/umi_methods.py
@@ -142,11 +142,15 @@ def joinedFastqIterate(fastq_iterator1, fastq_iterator2, strict=True):
 ###############################################################################
 
 
-def getKneeEstimate(cell_barcode_counts, cell_number=False, plotfile_prefix=None):
+def getKneeEstimate(cell_barcode_counts,
+                    expect_cells=False,
+                    cell_number=False,
+                    plotfile_prefix=None):
     ''' estimate the number of "true" cell barcodes
 
     input:
          cell_barcode_counts = dict(key = barcode, value = count)
+         expect_cells (optional) = define the expected number of cells
          cell_number (optional) = define number of cell barcodes to accept
          plotfile_prefix = (optional) prefix for plots
 
@@ -168,29 +172,38 @@ def getKneeEstimate(cell_barcode_counts, cell_number=False, plotfile_prefix=None
     xx_values = 1000  # how many x values for density plot
     xx = np.linspace(log_counts.min(), log_counts.max(), xx_values)
 
-    if cell_number:
+    if cell_number:  # we have a prior hard expectation on the number of cells
         threshold = counts[cell_number]
 
     else:
         local_mins = argrelextrema(density(xx), np.less)[0]
         local_min = None
-
-        # TS: Set of heuristic thresholds to decide which local minimum to select
-        # This is very unlikely to be the best way to achieve this!
-        for poss_local_min in local_mins[::-1]:
-            if (poss_local_min >= 0.2 * xx_values and
-                (log_counts.max() - xx[poss_local_min] > 1 or
-                 xx[poss_local_min] < log_counts.max()/2)):
-                local_min = poss_local_min
-                break
-
         local_mins_counts = []
-        for pos in xx[local_mins]:
-            threshold = np.power(10, pos)
-            passing_threshold = sum([y > threshold
-                                     for x, y in cell_barcode_counts.items()])
 
+        for poss_local_min in local_mins[::-1]:
+
+            passing_threshold = sum([y > np.power(10, xx[poss_local_min])
+                                     for x, y in cell_barcode_counts.items()])
             local_mins_counts.append(passing_threshold)
+
+            if not local_min:   # if we have selected a local min yet
+                if expect_cells:  # we have a "soft" expectation
+                    # the last threshold here prevents selecting a local
+                    # minima with v.low counts
+                    if (passing_threshold > expect_cells * 0.1 and
+                        passing_threshold <= expect_cells and 
+                        poss_local_min >= 0.05 * xx_values): 
+                        local_min = poss_local_min
+
+                else:  # we have no prior expectation
+                    # TS: In abscence of any expectation (either hard or soft),
+                    # this set of heuristic thresholds are used to decide
+                    # which local minimum to select.
+                    # This is very unlikely to be the best way to achieve this!
+                    if (poss_local_min >= 0.2 * xx_values and
+                        (log_counts.max() - xx[poss_local_min] > 1 or
+                         xx[poss_local_min] < log_counts.max()/2)):
+                        local_min = poss_local_min
 
         if local_min is not None:
             threshold = np.power(10, xx[local_min])
@@ -383,12 +396,13 @@ def getErrorCorrectMapping(cell_barcodes, whitelist, threshold=1):
 
 
 def getCellWhitelist(cell_barcode_counts,
+                     expect_cells=False,
                      cell_number=False,
                      error_correct_threshold=0,
                      plotfile_prefix=None):
 
     cell_whitelist = getKneeEstimate(
-        cell_barcode_counts, cell_number, plotfile_prefix)
+        cell_barcode_counts, expect_cells, cell_number, plotfile_prefix)
 
     if cell_whitelist is None:
         U.error("No local minima was accepted. Recommend checking the plot "

--- a/umi_tools/umi_methods.py
+++ b/umi_tools/umi_methods.py
@@ -188,11 +188,8 @@ def getKneeEstimate(cell_barcode_counts,
 
             if not local_min:   # if we have selected a local min yet
                 if expect_cells:  # we have a "soft" expectation
-                    # the last threshold here prevents selecting a local
-                    # minima with v.low counts
                     if (passing_threshold > expect_cells * 0.1 and
-                        passing_threshold <= expect_cells and
-                        poss_local_min >= 0.05 * xx_values):
+                        passing_threshold <= expect_cells):
                         local_min = poss_local_min
 
                 else:  # we have no prior expectation

--- a/umi_tools/whitelist.py
+++ b/umi_tools/whitelist.py
@@ -13,90 +13,11 @@ Purpose
 Extract cell barcodes and identify the most likely true barcodes using
 the 'knee' method.
 
-Use the --set-cell-number option if you want to manually set the
-number of accepted cell barcodes. Note that the exact number of of
-cell barcodes in the outputted whitelist may be slightly less than
-this if there are multiple cells observed with the same frequency at
-the threshold between accepted and rejected cell barcodes.
-
-
-Barcode extraction
-------------------
-
-There are two methods enabled to extract the umi barocode (+/- cell
-barcode). For both methods, the patterns should be provided using the
---bc-pattern and --bc-pattern options. The method is specified using
-the --extract-method option
-
--'string':
-       This should be used where the barcodes are always in the same
-       place in the read.
-
-       - N = UMI position (required)
-       - C = cell barcode position (optional)
-       - X = sample position (optional)
-
-       Bases with Ns and Cs will be extracted and added to the read
-       name. The corresponding sequence qualities will be removed from
-       the read. Bases with an X will be reattached to the read.
-
-       E.g. If the pattern is NNNNCC,
-       Then the read:
-       @HISEQ:87:00000000 read1
-       AAGGTTGCTGATTGGATGGGCTAG
-       DA1AEBFGGCG01DFH00B1FF0B
-       +
-       will become:
-       @HISEQ:87:00000000_TT_AAGG read1
-       GCTGATTGGATGGGCTAG
-       1AFGGCG01DFH00B1FF0B
-       +
-
-       where 'TT' is the cell barcode and 'AAGG' is the UMI.
-
--'regex'
-       This method allows for more flexible barcode extraction and
-       should be used where the cell barcodes are variable in
-       length. Alternatively, the regex option can also be used to
-       filter out reads which do not contain an expected adapter
-       sequence.
-
-       The expected groups in the regex are:
-
-       umi_n = UMI positions, where n can be any value (required)
-       cell_n = cell barcode positions, where n can be any value (optional)
-       discard_n = positions to discard, where n can be any value (optional)
-
-       UMI positions and cell barcode positions will be extrated and
-       added to the read name. The corresponding sequence qualities
-       will be removed from the read. Discard bases and the
-       corresponding quality scores will be removed from the read. All
-       bases matched by other groups or componentts of the regex will
-       reattached to the read sequence
-
-       For example, the following regex can be used to extract reads
-       from the Klein et al inDrop data:
-
-       (?P<cell_1>.{8,12})(?P<discard_1>GAGTGATTGCTTGTGACGCCTT)(?P<cell_2>.{8})(?P<umi_1>.{6})T{3}.*
-
-       Where only reads with a 3' T-tail and GAGTGATTGCTTGTGACGCCTT in
-       the correct position to yield two cell barcodes of 8-12 and 8bp
-       respectively, and a 6bp UMI will be retained.
-
-       You can also specify fuzzy matching to allow errors. For example if
-       the discard group above was specified as below this would enable
-       matches with up to 2 errors in the discard_1 group.
-
-       (?P<discard_1>GAGTGATTGCTTGTGACGCCTT{s<=2})
-
-       Note that all UMIs must be the same length for downstream
-       processing with dedup, group or count commands
-
-
 Identifying the true cell barcodes
 ----------------------------------
 
-We use the distribution of counts per cell barcode to identify the
+In the absence of the --set-cell-number options (see below),
+we use the distribution of counts per cell barcode to identify the
 cut-off for 'true' UMIs (the 'knee'). See this blog post for a more
 detailed explanation:
 
@@ -105,23 +26,34 @@ https://cgatoxford.wordpress.com/2017/05/18/estimating-the-number-of-true-cell-b
 Counts per cell barcode can be performed using either read or unique
 UMI counts. Use --method=[read|umis] to set the counting method.
 
-You can supply the --plot-prefix option to visualise the set of
-thresholds considered for defining cell barcodes. This option will
-also generate a table containing the thresholds which were rejected if
-you want manually adjust the threshold a different threshold.
+The process of selecting the "best" local minima is not completely
+fullproof. We recommend users always run whitelist with the
+--plot-prefix option to visualise the set of thresholds considered for
+defining cell barcodes. This option will also generate a table
+containing the thresholds which were rejected if you want manually
+adjust the threshold a different threshold.
 
-Options
--------
+In addition, if you have some prior expectation on the maximum number
+of cells which may have been sequenced, you can provide this using the
+option --expect-cells (see below).
 
---3prime
-       By default the barcode is assumed to be on the 5' end of the
-       read, but use this option to sepecify that it is on the 3' end
-       instead. This option only works with --extact-method=string
-       since 3' encoding can be specified explicitly with a regex, e.g
-       ".*(?P<umi_1>.{5})$"
 
--L (string, filename)
-       Specify a log file to retain logging information and final statistics
+whitelist-specific options
+--------------------------
+
+--set-cell-number
+        Use this option to explicity set the number of cell barcodes
+        which should be accepted. Note that the exact number of cell
+        barcodes in the outputted whitelist may be slightly less than
+        this if there are multiple cells observed with the same
+        frequency at the threshold between accepted and rejected cell
+        barcodes.
+
+--expect-cells=[EXPECTED_CELLS]
+        An estimate for the number of true cell barcodes. The knee
+        method will now select the first threshold (order ascendingly)
+        which results in the number of cell barcodes accepted being <=
+        EXPECTED_CELLS and > EXPECTED_CELLS * 0.1.
 
 Usage:
 ------
@@ -166,9 +98,6 @@ example output:
 
 If --error-correct-threshold is set to 0, columns 2 and 4 will be empty.
 
-Command line options
---------------------
-
 '''
 import sys
 import regex
@@ -204,6 +133,9 @@ try:
 except ImportError:
     import umi_methods
 
+# add the generic docstring text
+__doc__ = __doc__ + U.GENERIC_DOCSTRING_WE
+
 
 def main(argv=None):
     """script main.
@@ -237,9 +169,9 @@ def main(argv=None):
                             "detection of the number of 'true' cell barcodes"))
     parser.add_option("--subset-reads",
                       dest="subset_reads", type="int",
-                      help=("Use only the first N reads to automatically "
-                            "identify the true cell barcodes. If N is greater "
-                            "than the number of reads, all reads will be used"))
+                      help=("Use the first N reads to automatically identify "
+                            "the true cell barcodes. If N is greater than the "
+                            "number of reads, all reads will be used"))
     parser.add_option("--error-correct-threshold",
                       dest="error_correct_threshold",
                       type="int",

--- a/umi_tools/whitelist.py
+++ b/umi_tools/whitelist.py
@@ -249,6 +249,11 @@ def main(argv=None):
                       dest="method",
                       choices=["reads", "umis"],
                       help=("Use reads or unique umi counts per cell"))
+    parser.add_option("--expect-cells",
+                      dest="expect_cells",
+                      type="int",
+                      help=("Prior expectation on the upper limit on the "
+                            "number of cells sequenced"))
     parser.add_option("--set-cell-number",
                       dest="cell_number",
                       type="int",
@@ -264,6 +269,7 @@ def main(argv=None):
                         read2_in=None,
                         plot_prefix=None,
                         subset_reads=100000000,
+                        expect_cells=False,
                         cell_number=False)
 
     # add common options (-h/--help, ...) and parse command line
@@ -271,6 +277,10 @@ def main(argv=None):
     (options, args) = U.Start(parser, argv=argv,
                               add_group_dedup_options=False,
                               add_sam_options=False)
+
+    if options.expect_cells and options.cell_number:
+        U.error("Cannot supply both --expect-cells and "
+                "--cell-number options")
 
     if not options.pattern and not options.pattern2:
         if not options.read2_in:
@@ -442,6 +452,7 @@ def main(argv=None):
 
     cell_whitelist, true_to_false_map = umi_methods.getCellWhitelist(
         cell_barcode_counts,
+        options.expect_cells,
         options.cell_number,
         options.error_correct_threshold,
         options.plot_prefix)

--- a/umi_tools/whitelist.py
+++ b/umi_tools/whitelist.py
@@ -50,7 +50,7 @@ whitelist-specific options
         barcodes.
 
 --expect-cells=[EXPECTED_CELLS]
-        An estimate for the number of true cell barcodes. The knee
+        An upper limit estimate for the number of inputted cells. The knee
         method will now select the first threshold (order ascendingly)
         which results in the number of cell barcodes accepted being <=
         EXPECTED_CELLS and > EXPECTED_CELLS * 0.1.


### PR DESCRIPTION
Introduces the `--expect-cells` option for `whitelist` - as per the [CellRanger pipeline](https://support.10xgenomics.com/single-cell-gene-expression/software/pipelines/latest/using/count)

This is a half way house between full automation and the user defining the exact number of cells present. Should allow the user obtain an automatic estimate of the number of true cell barcodes with some prior information about the upper limit on how many cells have been sequenced. Use of this options assumes the user has at least a reasonable estimate of the number of cells as discussed [here](https://assets.contentful.com/an68im79xiti/57MmukfLzqI4WMeyKQMqom/557f2d3119e7cd7bb819a22b28118925/CG000091_10x_Technical_Note_Guidelines_on_Accurate_Target_Cell_Count.pdf) and that the capture rate exceeds 10% (reasonable assumption for 10X and indrop, not for dropseq).
