### PR TITLE
{is} remove tryexcept

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,6 @@
 include ez_setup.py
 # extensions
 include umi_tools/*.pyx
-include umis_tools/*.c
+include umi_tools/*.c
 # requirements.txt
 include requirements.txt

--- a/tests/test_style.py
+++ b/tests/test_style.py
@@ -29,6 +29,7 @@ IGNORE = set(('E201',  # whitespace after '('
               'E122',  # continuation line missing indentation or outdented
               'E129',  # visually indented line with same indent as next logical line
               'E265',  # block comment should start with '# '
+              'E402',  # module level import not at top of file because matplotlib
               'E501',  # line too long (82 > 79 characters)
               'E731',  # do not assign a lambda expression, use a def
               'W191',

--- a/umi_tools/count.py
+++ b/umi_tools/count.py
@@ -28,21 +28,9 @@ import pysam
 import pandas as pd
 import numpy as np
 
-try:
-    import umi_tools.Utilities as U
-except ImportError:
-    import Utilities as U
-
-try:
-    import umi_tools.network as network
-except ImportError:
-    import network
-
-try:
-    import umi_tools.umi_methods as umi_methods
-except ImportError:
-    import umi_methods
-
+import umi_tools.Utilities as U
+import umi_tools.network as network
+import umi_tools.umi_methods as umi_methods
 
 # add the generic docstring text
 __doc__ = __doc__ + U.GENERIC_DOCSTRING

--- a/umi_tools/count_tab.py
+++ b/umi_tools/count_tab.py
@@ -42,20 +42,9 @@ from builtins import dict
 
 from functools import partial
 
-try:
-    import umi_tools.Utilities as U
-except ImportError:
-    import Utilities as U
-
-try:
-    import umi_tools.network as network
-except ImportError:
-    import network
-
-try:
-    import umi_tools.umi_methods as umi_methods
-except ImportError:
-    import umi_methods
+import umi_tools.Utilities as U
+import umi_tools.network as network
+import umi_tools.umi_methods as umi_methods
 
 # add the generic docstring text
 __doc__ = __doc__ + U.GENERIC_DOCSTRING

--- a/umi_tools/dedup.py
+++ b/umi_tools/dedup.py
@@ -63,20 +63,9 @@ import pysam
 import pandas as pd
 import numpy as np
 
-try:
-    import umi_tools.Utilities as U
-except ImportError:
-    import Utilities as U
-
-try:
-    import umi_tools.network as network
-except ImportError:
-    import network
-
-try:
-    import umi_tools.umi_methods as umi_methods
-except ImportError:
-    import umi_methods
+import umi_tools.Utilities as U
+import umi_tools.network as network
+import umi_tools.umi_methods as umi_methods
 
 
 # add the generic docstring text

--- a/umi_tools/extract.py
+++ b/umi_tools/extract.py
@@ -173,25 +173,8 @@ except ImportError:
     # Python 3
     izip = zip
 
-try:
-    import umi_tools.Utilities as U
-except ImportError:
-    import Utilities as U
-
-try:
-    import umi_tools.network as network
-except ImportError:
-    import network
-
-try:
-    from umi_tools._dedup_umi import edit_distance
-except:
-    from _dedup_umi import edit_distance
-
-try:
-    import umi_tools.umi_methods as umi_methods
-except ImportError:
-    import umi_methods
+import umi_tools.Utilities as U
+import umi_tools.umi_methods as umi_methods
 
 
 def main(argv=None):

--- a/umi_tools/group.py
+++ b/umi_tools/group.py
@@ -85,22 +85,10 @@ from builtins import dict
 from future.utils import iteritems
 
 import pysam
-import numpy as np
 
-try:
-    import umi_tools.Utilities as U
-except ImportError:
-    import Utilities as U
-
-try:
-    import umi_tools.network as network
-except ImportError:
-    import network
-
-try:
-    import umi_tools.umi_methods as umi_methods
-except ImportError:
-    import umi_methods
+import umi_tools.Utilities as U
+import umi_tools.network as network
+import umi_tools.umi_methods as umi_methods
 
 # add the generic docstring text
 __doc__ = __doc__ + U.GENERIC_DOCSTRING

--- a/umi_tools/network.py
+++ b/umi_tools/network.py
@@ -14,13 +14,8 @@ import sys
 import regex
 import numpy as np
 
-try:
-    from umi_tools._dedup_umi import edit_distance
-    import umi_tools.Utilities as U
-
-except:
-    from _dedup_umi import edit_distance
-    import Utilities as U
+from umi_tools._dedup_umi import edit_distance
+import umi_tools.Utilities as U
 
 sys.setrecursionlimit(10000)
 

--- a/umi_tools/network.py
+++ b/umi_tools/network.py
@@ -8,6 +8,8 @@ network.py - Network methods for dealing with UMIs
 :Tags: Python UMI
 
 '''
+
+from __future__ import absolute_import
 import collections
 import itertools
 import sys

--- a/umi_tools/umi_methods.py
+++ b/umi_tools/umi_methods.py
@@ -9,6 +9,7 @@ umi_methods.py - Methods for dealing with UMIs
 
 '''
 
+from __future__ import absolute_import
 import itertools
 import collections
 import random

--- a/umi_tools/umi_methods.py
+++ b/umi_tools/umi_methods.py
@@ -12,11 +12,13 @@ umi_methods.py - Methods for dealing with UMIs
 import itertools
 import collections
 import random
-import numpy as np
 import pysam
 import re
 from scipy.stats import gaussian_kde
 from scipy.signal import argrelextrema
+import matplotlib
+# require to run on systems with no X11
+matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 import matplotlib.lines as mlines
 import numpy as np
@@ -26,15 +28,9 @@ from functools import partial
 from future.utils import iteritems
 from builtins import dict
 
-try:
-    import umi_tools.Utilities as U
-except:
-    import Utilities as U
+import umi_tools.Utilities as U
+from umi_tools._dedup_umi import edit_distance
 
-try:
-    from umi_tools._dedup_umi import edit_distance
-except:
-    from _dedup_umi import edit_distance
 
 RANGES = {
     'phred33': (33, 77),

--- a/umi_tools/umi_tools.py
+++ b/umi_tools/umi_tools.py
@@ -28,8 +28,6 @@ To use a specific tool, type::
 import os
 import sys
 import imp
-import matplotlib
-matplotlib.use('Agg')
 
 
 def main(argv=None):

--- a/umi_tools/whitelist.py
+++ b/umi_tools/whitelist.py
@@ -186,8 +186,6 @@ except ImportError:
     izip = zip
 
 
-
-
 def main(argv=None):
     """script main.
 

--- a/umi_tools/whitelist.py
+++ b/umi_tools/whitelist.py
@@ -173,8 +173,9 @@ Command line options
 import sys
 import regex
 import collections
-import pyximport
-pyximport.install(build_in_temp=False)
+
+import umi_tools.Utilities as U
+import umi_tools.umi_methods as umi_methods
 
 # python 3 doesn't require izip
 try:
@@ -184,25 +185,7 @@ except ImportError:
     # Python 3
     izip = zip
 
-try:
-    import umi_tools.Utilities as U
-except ImportError:
-    import Utilities as U
 
-try:
-    import umi_tools.network as network
-except ImportError:
-    import network
-
-try:
-    from umi_tools._dedup_umi import edit_distance
-except:
-    from _dedup_umi import edit_distance
-
-try:
-    import umi_tools.umi_methods as umi_methods
-except ImportError:
-    import umi_methods
 
 
 def main(argv=None):


### PR DESCRIPTION
Removes try except statements from around the import statements. 

I think these were neccessary because previously if you imported ran in a local directory that contained an `umi_tools` package, it would try to load from there and then get confused, which messed with the tests. This is fixed by adding `from __future__ import absolute_import`
also moved `matplotlib` backend specification to umi_methods.py from `umi_tools.py`
