### PR TITLE
{ts} debug no positions

### DIFF
--- a/umi_tools/dedup.py
+++ b/umi_tools/dedup.py
@@ -387,12 +387,12 @@ def main(argv=None):
     if not options.ignore_umi:  # otherwise processor has not been used
         U.info("Total number of positions deduplicated: %i" %
                processor.UMIClusterer.positions)
-        U.info("Mean number of unique UMIs per position: %.2f" %
-               (float(processor.UMIClusterer.total_umis_per_position) /
-                processor.UMIClusterer.positions))
-        U.info("Max. number of unique UMIs per position: %i" %
-               processor.UMIClusterer.max_umis_per_position)
-
+        if processor.UMIClusterer.positions > 0:
+            U.info("Mean number of unique UMIs per position: %.2f" %
+                   (float(processor.UMIClusterer.total_umis_per_position) /
+                    processor.UMIClusterer.positions))
+            U.info("Max. number of unique UMIs per position: %i" %
+                   processor.UMIClusterer.max_umis_per_position)
     U.Stop()
 
 if __name__ == "__main__":

--- a/umi_tools/dedup.py
+++ b/umi_tools/dedup.py
@@ -394,7 +394,7 @@ def main(argv=None):
             U.info("Max. number of unique UMIs per position: %i" %
                    processor.UMIClusterer.max_umis_per_position)
         else:
-            U.info("The BAM did not contain any valid "
+            U.warn("The BAM did not contain any valid "
                    "reads/read pairs for deduplication")
 
     U.Stop()

--- a/umi_tools/dedup.py
+++ b/umi_tools/dedup.py
@@ -393,6 +393,10 @@ def main(argv=None):
                     processor.UMIClusterer.positions))
             U.info("Max. number of unique UMIs per position: %i" %
                    processor.UMIClusterer.max_umis_per_position)
+        else:
+            U.info("The BAM did not contain any valid "
+                   "reads/read pairs for deduplication")
+
     U.Stop()
 
 if __name__ == "__main__":

--- a/umi_tools/umi_methods.py
+++ b/umi_tools/umi_methods.py
@@ -1432,7 +1432,11 @@ class get_bundles:
 
             # get the umi +/- cell barcode and update dictionaries
             if self.options.ignore_umi:
-                umi, cell = "", ""
+                if self.options.per_cell:
+                    umi, cell = self.barcode_getter(read)
+                    umi = ""
+                else:
+                    umi, cell = "", ""
             else:
                 umi, cell = self.barcode_getter(read)
 


### PR DESCRIPTION
Resolves (#190) as far as I can tell. Have confirmed that `dedup` previously errored with non-informative message when input BAM containing no reads. This is no longer the case. If there are no positions for de-duplication, this is now raised as a warning in the logfile but exit status is 0. 