### PR TITLE
{ts} debug bc pattern2

### DIFF
--- a/umi_tools/extract.py
+++ b/umi_tools/extract.py
@@ -217,10 +217,10 @@ def main(argv=None):
 
         if options.pattern2:
             try:
-                options.pattern2 = regex.compile(options.barcode_regex2)
+                options.pattern2 = regex.compile(options.pattern2)
             except regex.Error:
                 U.error("barcode_regex2 '%s' is not a "
-                        "valid regex" % options.barcode_regex2)
+                        "valid regex" % options.barcode_pattern2)
 
     # check whether the regex contains a umi group(s) and cell groups(s)
     if options.extract_method == "regex":

--- a/umi_tools/extract.py
+++ b/umi_tools/extract.py
@@ -220,7 +220,7 @@ def main(argv=None):
                 options.pattern2 = regex.compile(options.pattern2)
             except regex.Error:
                 U.error("barcode_regex2 '%s' is not a "
-                        "valid regex" % options.barcode_pattern2)
+                        "valid regex" % options.pattern2)
 
     # check whether the regex contains a umi group(s) and cell groups(s)
     if options.extract_method == "regex":

--- a/umi_tools/umi_methods.py
+++ b/umi_tools/umi_methods.py
@@ -698,7 +698,7 @@ class ExtractFilterAndUpdate:
             cell, umi, umi_quals, new_seq, new_quals = ("",)*5
 
         if self.pattern2:
-            bc2, sequence2 = self.extract(read2.seq)
+            bc2, sequence2 = self.extract(read2.seq, read=2)
             bc_qual2, seq_qual2 = self.extract(read2.quals)
             umi_quals2 = [bc_qual2[x] for x in self.umi_bases2]
 


### PR DESCRIPTION
Multiple debugs for use of  `--bc-pattern`. The most worrying is that when using `--bc-pattern` and `--bc-pattern2`, the number of bases removed from read2 = len(pattern) not len(pattern2)! (9354d2660425eea58e459b17ffbb834ab7c45455) This is obviously not a problem when pattern and pattern2 are the same length, as is frequently the case, but the user will be unaware of this issue, unless pattern2 is longer than pattern in which case an error will be thrown.