### PR TITLE
Tom smith cgat fuzzy doc patch

### DIFF
--- a/doc/Single_cell_tutorial.md
+++ b/doc/Single_cell_tutorial.md
@@ -358,7 +358,7 @@ This translates to: 8-12 characters (group="cell_1"), followed by "GAGTGATTGCTTG
 
 The other benefit of using a regex is that we can perform ['fuzzy'](https://pypi.python.org/pypi/regex/) matching. For example, the inDrop adapter sequence is 22bp long so it may sometimes contain base calling errors. We can allow usp to two substituions like so:
 
-`--bc-pattern="(?P<cell_1>.{8,12})(?P<discard_1>GAGTGATTGCTTGTGACGCCTT{s<=2})(?P<cell_2>.{8})(?P<umi_1>.{6})T{3}.*"`
+`--bc-pattern="(?P<cell_1>.{8,12})(?P<discard_1>GAGTGATTGCTTGTGACGCCTT){s<=2}(?P<cell_2>.{8})(?P<umi_1>.{6})T{3}.*"`
 
 It should be possible to encode any conceivable pattern of barcodes using a regex.
 

--- a/umi_tools/Utilities.py
+++ b/umi_tools/Utilities.py
@@ -1226,7 +1226,7 @@ the --extract-method option
        the discard group above was specified as below this would enable
        matches with up to 2 errors in the discard_1 group.
 
-       (?P<discard_1>GAGTGATTGCTTGTGACGCCTT{s<=2})
+       (?P<discard_1>GAGTGATTGCTTGTGACGCCTT){s<=2}
 
        Note that all UMIs must be the same length for downstream
        processing with dedup, group or count commands


### PR DESCRIPTION
Rectifies error in documentation identified by @hy09 (#211).

Note - fuzzy matching is covered in the testing and the regex provided defines the fuzzy match incorrectly. This should also be updated in due course in case any one ever looks at the testing to help them define their regex (unlikely but possible I guess)