### PR TITLE
{ts} add retain umi option

### DIFF
--- a/umi_tools/extract.py
+++ b/umi_tools/extract.py
@@ -77,6 +77,7 @@ from __future__ import absolute_import
 import sys
 import regex
 import collections
+import optparse
 
 # python 3 doesn't require izip
 try:
@@ -106,6 +107,9 @@ def main(argv=None):
     parser = U.OptionParser(version="%prog version: $Id$",
                             usage=globals()["__doc__"])
 
+    # (Experimental option) Retain the UMI in the sequence read"
+    parser.add_option("--retain-umi", dest="retain_umi", action="store_true",
+                      help=optparse.SUPPRESS_HELP)
     parser.add_option("-p", "--bc-pattern", dest="pattern", type="string",
                       help="Barcode pattern")
     parser.add_option("--bc-pattern2", dest="pattern2", type="string",
@@ -180,6 +184,9 @@ def main(argv=None):
     (options, args) = U.Start(parser, argv=argv,
                               add_group_dedup_options=False,
                               add_sam_options=False)
+
+    if options.retain_umi and not options.extract_method=="regex":
+        raise ValueError("option --retain-umi only works with --extract-method=regex")
 
     if options.quality_filter_threshold or options.quality_filter_mask:
         if not options.quality_encoding:
@@ -288,7 +295,8 @@ def main(argv=None):
         options.quality_encoding,
         options.quality_filter_threshold,
         options.quality_filter_mask,
-        options.filter_cell_barcode)
+        options.filter_cell_barcode,
+        options.retain_umi)
 
     if options.filter_cell_barcode:
         cell_whitelist, false_to_true_map = umi_methods.getUserDefinedBarcodes(

--- a/umi_tools/extract.py
+++ b/umi_tools/extract.py
@@ -185,7 +185,7 @@ def main(argv=None):
                               add_group_dedup_options=False,
                               add_sam_options=False)
 
-    if options.retain_umi and not options.extract_method=="regex":
+    if options.retain_umi and not options.extract_method == "regex":
         raise ValueError("option --retain-umi only works with --extract-method=regex")
 
     if options.quality_filter_threshold or options.quality_filter_mask:

--- a/umi_tools/umi_methods.py
+++ b/umi_tools/umi_methods.py
@@ -560,12 +560,12 @@ def extractSeqAndQuals(seq, quals, umi_bases, cell_bases, discard_bases,
             (ix not in cell_bases)):
 
             # if we are retaining the umi, this base is both seq and umi
-            if retain_umi: 
+            if retain_umi:
                 new_quals += qual
                 new_seq += base
                 umi_quals += qual
 
-            else: # base is either seq or umi
+            else:  # base is either seq or umi
                 if ix not in umi_bases:
                     new_quals += qual
                     new_seq += base
@@ -574,7 +574,7 @@ def extractSeqAndQuals(seq, quals, umi_bases, cell_bases, discard_bases,
 
         elif ix in cell_bases:
             cell_quals += qual
-            
+
         ix += 1
 
     return new_seq, new_quals, umi_quals, cell_quals


### PR DESCRIPTION
@IanSudbery  - This branch introduces an experimental option `--retain-umi` in `extract` to retain the umi in the read sequence. 

I used this for some (slightly unusual) samples where ~2/3 of reads contain a 1-9bp sequence of non-template nucleotides which are added to the 5' end of the read prior to amplification. This is not by design! However, the benefit is that the first 9bp can be used as a pseudo-umi but the length and presence of the non-tempate nucleotides is not consistent so I also need to retain the pseudo-umi in the read sequence and allow the aligner to soft-clip where appropriate. The other option would have been to extract the soft-clipped bases from the BAM and annotate the BAM with these. However, this wouldn't have worked with `umi_tools dedup` due to the need for a uniform UMI length.

Since this option is very bespoke, I've hidden the option from users.