### PR TITLE
debugs wide-format counts output for #227

### DIFF
--- a/umi_tools/count.py
+++ b/umi_tools/count.py
@@ -153,12 +153,11 @@ def main(argv=None):
             cells = set()
             for line in inf:
                 gene, cell, gene_count = line.strip().split("\t")
-                if gene not in genes:
-                    genes.add(gene)
+                genes.add(gene)
+                cells.add(cell)
+
+                if gene not in gene_counts_dict:
                     gene_counts_dict[gene] = {}
-                    if cell not in cells:
-                        cells.add(cell)
-                        gene_counts_dict[gene][cell] = 0
 
                 gene_counts_dict[gene][cell] = gene_count
 


### PR DESCRIPTION
Does what is says on the tin. I introduced this bug in the simplification of `count` output. This wasn't picked up in the test since the test input only has two cells.