### PR TITLE
Alter iter_nearest_neighbours to produce combinations not permutations

### DIFF
--- a/umi_tools/network.py
+++ b/umi_tools/network.py
@@ -111,7 +111,7 @@ def iter_nearest_neighbours(umis, substr_idx):
         for idx, substr_map in substr_idx.items():
             u_sub = u[slice(*idx)]
             neighbours = neighbours.union(substr_map[u_sub])
-            neighbours.difference_update(umis[:i])
+        neighbours.difference_update(umis[:i])
         for nbr in neighbours:
             yield u, nbr
 

--- a/umi_tools/network.py
+++ b/umi_tools/network.py
@@ -106,12 +106,12 @@ def iter_nearest_neighbours(umis, substr_idx):
     use substring dict to get (approximately) all the nearest neighbours to
     each in a set of umis.
     '''
-    for u in umis:
+    for i, u in enumerate(umis, 1):
         neighbours = set()
         for idx, substr_map in substr_idx.items():
             u_sub = u[slice(*idx)]
             neighbours = neighbours.union(substr_map[u_sub])
-        neighbours.remove(u)
+            neighbours.difference_update(umis[:i])
         for nbr in neighbours:
             yield u, nbr
 


### PR DESCRIPTION
I realised that currently the `iter_nearest_neighbours` function, which is used for umi bundles > 25, produces pairs similar to those produced by `it.permutations`, i.e. (B, A) as well as (A, B), whereas for umi_bundles < 25, `it.combinations` is used (producing just (A, B)). This change would make the `iter_nearest_neighbours` function also produce combinations. I don't know whether this bug had any difference on the output, but even if not I think it should reduce the number of pairwise edit distances that have to be computed even further (by exactly half, I'm guessing...?)