### PR TITLE
Update count_tab.py

### DIFF
--- a/umi_tools/count_tab.py
+++ b/umi_tools/count_tab.py
@@ -24,9 +24,9 @@ NS500668:144:H5FCJBGXY:3:23405:3971:19716_CGATG     ENSG00000225972.1
 
 You can perform any required file transformation and pipe the output
 directly to count_tab. For example to pipe output from featureCounts
-with the '-R' option you can do the following:
+with the '-R CORE' option you can do the following:
 
-    awk '$2=="Assigned" {print $1"\t"$3}' my.bam.featureCounts| sort -k2 |
+    awk '$2=="Assigned" {print $1"\t"$4}' my.bam.featureCounts | sort -k2 |
     umi_tools count_tab -S gene_counts.tsv -L count.log
 
 The tab file is assumed to contain each read id once only. For paired


### PR DESCRIPTION
From the Subread Users Guide:

"When CORE format is specified, a tab-delimited file will be generated for each input file. Name of each generated file is the input file name added with ‘.featureCounts’. Each generated file contains four columns including read name, status (assigned or the reason if not assigned), number of targets and target list. A target is a feature or a meta-feature. Items in the target lists is separated by comma. If a read is not assigned, its number of targets will be set as -1."

Hence, column for target (i.e. gene id) must be $4 instead of $3.