### PR TITLE
Fixed "processed read" diagram in QUICK_START.md

### DIFF
--- a/doc/QUICK_START.md
+++ b/doc/QUICK_START.md
@@ -98,7 +98,7 @@ followed by 2 more random bases. Thus the `--bc-pattern` would be
                       library
 
 
-     Processed read: CCGGTTGCCCAATTGCCAAATTTTGGGGCCCCTATGAGCTA
+     Processed read: CCGGTTGCCCAATTGCCAAATTTTGGGGCCCCTATGAGCTAG
                      ^^^^  
 
 The processed reads could then be passed to a demultiplexing tool to


### PR DESCRIPTION
Read: TAGCCGGCTTTGCCCAATTGCCAAATTTTGGGGCCCCTATGAGCTAG 
Barcode: NNNXXXXNN

Thus processed read should be CCGGTTGCCCAATTGCCAAATTTTGGGGCCCCTATGAGCTAG. There was a base missing at the end of the sequence.