### PR TITLE
added `__version__`

### DIFF
--- a/umi_tools/__init__.py
+++ b/umi_tools/__init__.py
@@ -1,1 +1,3 @@
+from __future__ import absolute_import
+
 from umi_tools.version import __version__

--- a/umi_tools/__init__.py
+++ b/umi_tools/__init__.py
@@ -1,0 +1,1 @@
+from umi_tools.version import __version__


### PR DESCRIPTION
Having a `umi_tools.__version__` string
is the standard recommended Python way
to make the version number accessible.
This commit does that.