### PR TITLE
Debug py2 test fails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ before_install:
   - pip install cython
   - pip install pandas==0.19
   - pip install scipy
+  - pip install matplotlib==2.2.3  # can remove once py2 support dropped
 install:
   - python setup.py install
 


### PR DESCRIPTION
Matplotlib >= 3.0 doesn't support py2. Causes fail:
https://travis-ci.org/CGATOxford/UMI-tools/jobs/433394475#L586-L600

Switching to hardcoding 2.2.3 whilst we maintain py2 support ourselves. 