### PR TITLE
Use of read.tags += was causing a change of type for some tags. Now i…

### DIFF
--- a/umi_tools/group.py
+++ b/umi_tools/group.py
@@ -256,8 +256,8 @@ def main(argv=None):
                 for read in reads:
                     if outfile:
                         # Add the 'UG' tag to the read
-                        read.tags += [('UG', unique_id)]
-                        read.tags += [(options.umi_group_tag, top_umi)]
+                        read.set_tag('UG', unique_id)
+                        read.set_tag(options.umi_group_tag, top_umi)
                         outfile.write(read)
 
                     if options.tsv:

--- a/umi_tools/umi_methods.py
+++ b/umi_tools/umi_methods.py
@@ -1112,7 +1112,7 @@ def metafetcher(bamfile, metacontig2contig, metatag):
     for metacontig in metacontig2contig:
         for contig in metacontig2contig[metacontig]:
             for read in bamfile.fetch(contig):
-                read.tags += [(metatag, metacontig)]
+                read.set_tag(metatag, metacontig)
                 yield read
 
 


### PR DESCRIPTION
fix for #285 

Use of `read.tags += [(tag, value)]` was cuasing a change in the type for some tags. Specifically if an application had set the read group tag (`RG`), using a `Z` type, after passing through `group` the type of the RG tag would be `A`. 

The samtools specification requires that the RG tag has the type `Z`, and so bam validation tools were failing. 

I belive this is happening becausae when

 `read.tags += [(tag, value)]`

`(tag,value)` pairs are being extracted from the `tags` attribute, a new list of `(tag, value)` pairs is being created, and this is being passed back to the read. In this process a guess is being made as to the type. 

Now uses `read.set_tag(tag, value)`, which doesn't have this problem.

Note that this doesn't apply to all versions of pysam. This problem is present in 0.11 and 0.12, but not in 0.15

