### PR TITLE
Refactored UMIClusterer to remove unncessesary arguement to __call__

### DIFF
--- a/umi_tools/count.py
+++ b/umi_tools/count.py
@@ -139,7 +139,7 @@ def main(argv=None):
     # specified options.method
 
     processor = network.UMIClusterer(options.method)
-    
+
     for bundle, key, status in bundle_iterator(inreads):
         if status == "single_read":
             continue

--- a/umi_tools/count.py
+++ b/umi_tools/count.py
@@ -135,6 +135,11 @@ def main(argv=None):
         only_count_reads=True,
         metacontig_contig=metacontig2contig)
 
+    # set up UMIClusterer functor with methods specific to
+    # specified options.method
+
+    processor = network.UMIClusterer(options.method)
+    
     for bundle, key, status in bundle_iterator(inreads):
         if status == "single_read":
             continue
@@ -150,14 +155,8 @@ def main(argv=None):
             input_reads += 1000000
             U.info("Parsed %i input reads" % input_reads)
 
-        # set up UMIClusterer functor with methods specific to
-        # specified options.method
-
-        processor = network.UMIClusterer(options.method)
-
         # group the umis
         groups = processor(
-            umis,
             counts,
             threshold=options.threshold)
 

--- a/umi_tools/count_tab.py
+++ b/umi_tools/count_tab.py
@@ -139,7 +139,6 @@ def main(argv=None):
 
             # group the umis
             groups = processor(
-                umis,
                 counts[cell],
                 threshold=options.threshold)
 

--- a/umi_tools/group.py
+++ b/umi_tools/group.py
@@ -219,7 +219,11 @@ def main(argv=None):
         return_read2=True,
         return_unmapped=output_unmapped,
         metacontig_contig=metacontig2contig)
-
+    
+    # set up UMIClusterer functor with methods specific to
+    # specified options.method
+    processor = network.UMIClusterer(options.method)
+    
     for bundle, key, status in bundle_iterator(inreads):
 
         # write out read2s and unmapped/chimeric (if these options are set)
@@ -246,13 +250,8 @@ def main(argv=None):
             input_reads += 1000000
             U.info("Parsed %i input reads" % input_reads)
 
-        # set up UMIClusterer functor with methods specific to
-        # specified options.method
-        processor = network.UMIClusterer(options.method)
-
         # group the umis
         groups = processor(
-            umis,
             counts,
             threshold=options.threshold)
 

--- a/umi_tools/group.py
+++ b/umi_tools/group.py
@@ -219,11 +219,11 @@ def main(argv=None):
         return_read2=True,
         return_unmapped=output_unmapped,
         metacontig_contig=metacontig2contig)
-    
+
     # set up UMIClusterer functor with methods specific to
     # specified options.method
     processor = network.UMIClusterer(options.method)
-    
+
     for bundle, key, status in bundle_iterator(inreads):
 
         # write out read2s and unmapped/chimeric (if these options are set)

--- a/umi_tools/network.py
+++ b/umi_tools/network.py
@@ -346,10 +346,11 @@ class UMIClusterer:
             self.get_connected_components = self._get_connected_components_null
             self.get_groups = self._group_unique
 
-    def __call__(self, umis, counts, threshold):
-        '''Counts is a dictionary that maps UMIs to their counts'''
+    def __call__(self, umis, threshold):
+        '''umis is a dictionary that maps UMIs to their counts'''
 
-        umis = list(umis)
+        counts = umis
+        umis = list(umis.keys())
 
         self.positions += 1
 
@@ -399,7 +400,7 @@ class ReadDeduplicator:
         umis = bundle.keys()
         counts = {umi: bundle[umi]["count"] for umi in umis}
 
-        clusters = self.UMIClusterer(umis, counts, threshold)
+        clusters = self.UMIClusterer(counts, threshold)
 
         final_umis = [cluster[0] for cluster in clusters]
         umi_counts = [sum(counts[umi] for umi in cluster)

--- a/umi_tools/sam_methods.py
+++ b/umi_tools/sam_methods.py
@@ -411,9 +411,9 @@ class get_bundles:
                 try:
                     umi, cell = self.barcode_getter(read)
                 except KeyError:
-                    error_msg = "Read skipped, missing umi and/or cell tag"  
+                    error_msg = "Read skipped, missing umi and/or cell tag"
                     if self.read_events[error_msg] == 0:
-                        
+
                         # pysam renamed .tostring -> to_string in 0.14
                         # .tostring requies access to the parent AlignmentFile
                         try:

--- a/umi_tools/sam_methods.py
+++ b/umi_tools/sam_methods.py
@@ -411,10 +411,18 @@ class get_bundles:
                 try:
                     umi, cell = self.barcode_getter(read)
                 except KeyError:
-                    error_msg = "Read skipped, missing umi and/or cell tag"
+                    error_msg = "Read skipped, missing umi and/or cell tag"  
                     if self.read_events[error_msg] == 0:
+                        
+                        # pysam renamed .tostring -> to_string in 0.14
+                        # .tostring requies access to the parent AlignmentFile
+                        try:
+                            formatted_read = read.to_string()
+                        except AttributeError:
+                            formatted_read = read.query_name
+
                         U.warn("At least one read is missing UMI and/or "
-                               "cell tag(s): %s" % read.to_string())
+                               "cell tag(s): %s" % formatted_read)
                     self.read_events[error_msg] += 1
                     continue
 


### PR DESCRIPTION
Call signature for `UMIClusterer` was `__call__(umis, counts, threshold=1)`  where `umis` was a list of UMIs and `counts` was a dictionary mapping UMIs to their counts. This seemed unnecesssary as `umis` could be recovered from `counts` with `counts.keys()`. When I wrote the API website page, I pretended it wasn't there. This pull makes the reality match the docs.

Also fixes pysam<0.14 errors if tag is missing. 
