### PR TITLE
fix python2 ImportError

### DIFF
--- a/umi_tools/Utilities.py
+++ b/umi_tools/Utilities.py
@@ -258,7 +258,10 @@ import tempfile
 import regex
 from umi_tools import __version__
 
-from builtins import bytes, chr
+try:
+    from builtins import bytes, chr # python3
+except:
+    pass # python2
 
 
 class DefaultOptions:


### PR DESCRIPTION
in python2: "ImportError: No module named builtins"
bytes and chr are built-in (with no import) in python2