### PR TITLE
Fix for incorrect output of dedup with --paired (#347)

### DIFF
--- a/umi_tools/sam_methods.py
+++ b/umi_tools/sam_methods.py
@@ -574,7 +574,6 @@ class TwoPassPairWriter:
         self.infile = infile
         self.outfile = outfile
         self.read1s = set()
-        self.read1s_done = set()
         self.chrom = None
 
     def write(self, read, unique_id=None, umi=None, unmapped=False):
@@ -590,9 +589,8 @@ class TwoPassPairWriter:
             self.write_mates()
             self.chrom = read.reference_name
 
-        key = read.query_name, read.next_reference_name, read.next_reference_start
-        if key not in self.read1s_done:
-            self.read1s.add(key)
+        key = read.query_name, read.next_reference_name, read.next_reference_start, read.reference_name, read.reference_start
+        self.read1s.add(key)
 
         self.outfile.write(read)
 
@@ -607,11 +605,10 @@ class TwoPassPairWriter:
             if any((read.is_unmapped, read.mate_is_unmapped, read.is_read1)):
                 continue
 
-            key = read.query_name, read.reference_name, read.reference_start
+            key = read.query_name, read.reference_name, read.reference_start, read.next_reference_name, read.next_reference_start
             if key in self.read1s:
                 self.outfile.write(read)
                 self.read1s.remove(key)
-                self.read1s_done.add(key)
 
         U.debug("%i mates remaining" % len(self.read1s))
 
@@ -629,7 +626,7 @@ class TwoPassPairWriter:
             if any((read.is_unmapped, read.mate_is_unmapped, read.is_read1)):
                 continue
 
-            key = read.query_name, read.reference_name, read.reference_start
+            key = read.query_name, read.reference_name, read.reference_start, read.next_reference_name, read.next_reference_start
             if key in self.read1s:
                 self.outfile.write(read)
                 self.read1s.remove(key)


### PR DESCRIPTION
This should fix #347. To test it, please use the test dataset provided ([here](https://drive.google.com/file/d/1fLmR7TdtutPkvVhh8gJ65-kTp2IFdPLj/view?usp=sharing)) and run
```
umi_tools dedup --paired --stdin umi_tools_bug_report.bam --verbose 0 -o
```