### PR TITLE
Fix for incorrect output of dedup with --paired (#347) in case of duplicated lines

### DIFF
--- a/umi_tools/sam_methods.py
+++ b/umi_tools/sam_methods.py
@@ -623,7 +623,7 @@ class TwoPassPairWriter:
         found = 0
         for read in self.infile.fetch(until_eof=True, multiple_iterators=True):
 
-            if read.is_unmapped:
+            if any((read.is_unmapped, read.mate_is_unmapped, read.is_read1)):
                 continue
 
             key = read.query_name, read.reference_name, read.reference_start


### PR DESCRIPTION
Due to the feedback from @IanSudbery, I have now just created a pull request for the trivial and easy fix for having multiple identical read1 alignments in the case the read2 alignment is missing by extending one condition.

Best,
Christian