### PR TITLE
Resolves travis fails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,11 @@ matrix:
     include:
         - os: linux
           sudo: required
-          python: 3.6.7
+          python: 3.7.3
           env: TEST_FUNCTIONALITY=1
         - os: linux
           sudo: required
-          python: 3.6.7
+          python: 3.7.3
           env: TEST_STYLE=1
 
 before_install:

--- a/umi_tools/dedup.py
+++ b/umi_tools/dedup.py
@@ -367,7 +367,7 @@ def main(argv=None):
 
     if not options.no_sort_output:
         # sort the output
-        pysam.sort("-o", sorted_out_name, "-O", sort_format, out_name)
+        pysam.sort("-o", sorted_out_name, "-O", sort_format, "--no-PG", out_name)
         os.unlink(out_name)  # delete the tempfile
 
     if options.stats:

--- a/umi_tools/group.py
+++ b/umi_tools/group.py
@@ -303,7 +303,7 @@ def main(argv=None):
         outfile.close()
         if not options.no_sort_output:
             # sort the output
-            pysam.sort("-o", sorted_out_name, "-O", sort_format, out_name)
+            pysam.sort("-o", sorted_out_name, "-O", sort_format, "--no-PG", out_name)
             os.unlink(out_name)  # delete the tempfile
 
     if options.tsv:


### PR DESCRIPTION
After a bit of digging, the source of the travis fails has been identified as `samtools` v1.10 (https://github.com/samtools/samtools/releases/tag/1.10) which now adds a header line to the output sam, containing the sort command itself. I took the easy route out and added the `--no-PG` to our `samtools sort` call. If we think that users may actually want to have this line included in the header for downstream purposes, we can update test script to strip the line out (since it includes the output directory which is randomly generated at test run time).
