### PR TITLE
fix umi-tools dependency on python hash function values 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ before_install:
   - pip install cython
   - pip install pandas
   - pip install scipy
+  - pip install siphashc>=2.1
 install:
   - python setup.py install
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ scipy
 matplotlib
 pybktree
 python>=3.5
+siphashc>=2.1


### PR DESCRIPTION
The umi-tools algorithm has an unfortunate dependency
on the actual hash values python generates on strings
With the anti-DOS mitigations from python 3.3, 
these change with every run.

This means, unless the user set's PYTHON_HASHSEED=0,
in addition to --random-seed, umi-tools output is non deterministic.

That is surprising, and also, undocumented except in github issues.

This PR forces the set to use the equivalent of PYTHON_HASHSEED=0 
in the one place that matters to the test cases.

I have not performed performance benchmarks - couldn't find such a facility
in the repo.

There is one remaining test case failing 'group_adjacency', 
but it also fails with PYTHON_HASHSEED=0 on a clean checkout
of either master or 1.1.1 - there is something else going on there.




