### PR TITLE
Fix "umi_tools command" prints stack trace

### DIFF
--- a/umi_tools/umi_tools.py
+++ b/umi_tools/umi_tools.py
@@ -32,33 +32,29 @@ import importlib
 from umi_tools import __version__
 
 
-def main(argv=None):
-
+def main():
     argv = sys.argv
 
-    path = os.path.abspath(os.path.dirname(__file__))
-
-    if len(argv) == 1 or argv[1] == "--help" or argv[1] == "-h":
+    if len(argv) <2 or argv[1] == "--help" or argv[1] == "-h":
         print("For full UMI-tools documentation, see: "
               "https://umi-tools.readthedocs.io/en/latest/\n")
         print(globals()["__doc__"])
+        return 0
 
-        return
-
-    elif len(argv) == 1 or argv[1] == "--version" or argv[1] == "-v":
+    if argv[1] == "--version" or argv[1] == "-v":
         print("UMI-tools version: %s" % __version__)
-
-        return
-
-    elif argv[2] in ["--help", "-h", "--help-extended"]:
-        print("UMI-Tools: Version %s" % __version__)
+        return 0
 
     command = argv[1]
+    
+    try:
+        module = importlib.import_module("umi_tools." + command, "umi_tools")
+    except ModuleNotFoundError:
+        print("'%s' is not a UMI-tools command. See 'umi_tools -h'." % command)
+        return 1
 
-    module = importlib.import_module("umi_tools." + command, "umi_tools")
-    # remove 'umi-tools' from sys.argv
-    del sys.argv[0]
-    module.main(sys.argv)
+    del sys.argv[0]  # remove 'umi-tools' from sys.argv
+    return module.main(sys.argv)
 
 if __name__ == "__main__":
     sys.exit(main())


### PR DESCRIPTION
Also:
- minor refactor
- pass return value from command through to sys.exit()
- pretty error if the command is not known

(Didn't test this PR myself yet, just trying to fix my "first launch" experience of getting a stack trace)

