### PR TITLE
Fix test_umi_tools.py

### DIFF
--- a/tests/test_umi_tools.py
+++ b/tests/test_umi_tools.py
@@ -237,7 +237,7 @@ def test_tool():
     fn = 'tests/tests.yaml'
     assert os.path.exists(fn), "tests.yaml does not exist!"
 
-    tool_tests = yaml.load(open(fn))
+    tool_tests = yaml.safe_load(open(fn))
 
     for test, values in sorted(list(tool_tests.items())):
         check_script.description = os.path.join(tool_name, test)


### PR DESCRIPTION
Changes to `pyyaml` mean that `yaml.load()` has been replaced with `yaml.safe_load()` and `yaml.full_load()`. Since we are only loading text from the testing configuration, I have replaced `yaml.load()` with `yaml.safe_load`
