### PR TITLE
Speed up writing mates

### DIFF
--- a/umi_tools/sam_methods.py
+++ b/umi_tools/sam_methods.py
@@ -12,6 +12,9 @@ import collections
 import re
 import random
 from functools import partial
+
+import pysam
+
 import umi_tools.Utilities as U
 
 
@@ -572,6 +575,7 @@ class TwoPassPairWriter:
 
     def __init__(self, infile, outfile, tags=False):
         self.infile = infile
+        self.mate_file = pysam.AlignmentFile(infile.filename)
         self.outfile = outfile
         self.read1s = set()
         self.chrom = None
@@ -601,7 +605,7 @@ class TwoPassPairWriter:
             U.debug("Dumping %i mates for contig %s" % (
                 len(self.read1s), self.chrom))
 
-        for read in self.infile.fetch(reference=self.chrom, multiple_iterators=True):
+        for read in self.mate_file.fetch(reference=self.chrom, multiple_iterators=False):
             if any((read.is_unmapped, read.mate_is_unmapped, read.is_read1)):
                 continue
 
@@ -621,7 +625,7 @@ class TwoPassPairWriter:
                len(self.read1s))
 
         found = 0
-        for read in self.infile.fetch(until_eof=True, multiple_iterators=True):
+        for read in self.mate_file.fetch(until_eof=True, multiple_iterators=False):
 
             if any((read.is_unmapped, read.mate_is_unmapped, read.is_read1)):
                 continue


### PR DESCRIPTION
Fixes #539.

When `TwoPassPairWriter` reaches the end of a contig, it calls `write_mates`, which reopens that contig from the start and scans through for remaining mates. To do this, `write_mates` uses `pysam.AlignmentFile.fetch(...., multiple_iterators=True)`. As the file uses is the same filehandle being used by `bundle_iterator`, then `multiple_iterators=True` ensures that the position in the file is not lost in this operation. 

`multiple_iterators=True` imposes some overhead. With a reasonable number of contigs this is not a problem, as the overhead is small compared to the cost of the scan. However, when alignment is done to the transcriptome, `write_mates` is called 100s of thousands of times, and for some reason, `fetch` calls the `__init__` of `psyam.RowIteratorRegion` 4 times for each call to `fetch`. This causes a serious slow down, such that adding `--paired` to the commandline slows the processing for an example file down from a couple of minutes to five hours. 

This PR changes `TwoPassPairWriter` so that it's `__init__` opens a second file handle to the input file. This allows it to drop the requirement to use `multiple_iterators=True` and returns the performance to near that of the performance without `--paired`. 

As far as I can tell, this does not change the output (i.e. the two handles act independently). I have tested this both on the test files and on an example transcriptome alignment provided in #539. 

Time to run is reduced from 5 hours to 200 seconds. 
