### PR TITLE
Add option to specify UMI separator in extract

### DIFF
--- a/umi_tools/extract.py
+++ b/umi_tools/extract.py
@@ -256,6 +256,9 @@ def main(argv=None):
                            "are not present in read1 input. This allows cell "
                            "barcode filtering of read1s without "
                            "considering read2s"))
+    group.add_option("--umi-separator",
+                     dest="umi_separator", type="string",
+                     help=("Separator to use to add UMI to the read name. Default: _"))
     parser.add_option_group(group)
 
     group = U.OptionGroup(parser, "[EXPERIMENTAl] barcode extraction options")
@@ -289,7 +292,8 @@ def main(argv=None):
                         reconcile=False,
                         either_read=False,
                         either_read_resolve="discard",
-                        ignore_suffix=False)
+                        ignore_suffix=False,
+                        umi_separator="_")
 
     # add common options (-h/--help, ...) and parse command line
 
@@ -384,7 +388,8 @@ def main(argv=None):
         options.filter_cell_barcode,
         options.retain_umi,
         options.either_read,
-        options.either_read_resolve)
+        options.either_read_resolve,
+        options.umi_separator)
 
     if options.filter_umi:
         umi_whitelist, false_to_true_map = whitelist_methods.getUserDefinedBarcodes(


### PR DESCRIPTION
Add option to specify UMI separator in umi_tools extract. The default stays as it is now ("_"). Allows users to change it to other strings.