### PR TITLE
check if gene_tag is empty

### DIFF
--- a/umi_tools/group.py
+++ b/umi_tools/group.py
@@ -285,7 +285,7 @@ def main(argv=None):
                         outfile.write(read)
 
                     if options.tsv:
-                        if options.per_gene:
+                        if options.per_gene and gene_tag is not None:
                             gene = read.get_tag(gene_tag)
                         else:
                             gene = "NA"


### PR DESCRIPTION
saving a flatfile will fail when `per_gene` is set and `gene_tag` is not set. This will occur when `per_gene` and `per_contig` are enabled: in this case, `gene_tag` cannot be set. In this case, `gene = read.get_tag(gene_tag)` will fail because `gene_tag is None`.