### PR TITLE
Fix lack of help messages in 1.1.4

### DIFF
--- a/tests/count_help
+++ b/tests/count_help
@@ -1,0 +1,124 @@
+
+count - Count reads per-gene using UMI and mapping coordinates
+
+Usage: umi_tools count [OPTIONS] --stdin=IN_BAM [--stdout=OUT_BAM]
+
+       note: If --stdout is ommited, standard out is output. To
+             generate a valid BAM file on standard out, please
+             redirect log with --log=LOGFILE or --log2stderr 
+
+For full UMI-tools documentation, see https://umi-tools.readthedocs.io/en/latest/
+
+Options:
+  --version             show program's version number and exit
+  --wide-format-cell-counts
+                        output the cell counts in a wide format (rows=genes,
+                        columns=cells)
+
+  count-specific options:
+
+  Barcode extraction options:
+    --extract-umi-method=GET_UMI_METHOD
+                        how is the read UMI +/ cell barcode encoded?
+                        [default=read_id]
+    --umi-separator=UMI_SEP
+                        separator between read id and UMI
+    --umi-tag=UMI_TAG   tag containing umi
+    --umi-tag-split=UMI_TAG_SPLIT
+                        split UMI in tag and take the first element
+    --umi-tag-delimiter=UMI_TAG_DELIM
+                        concatenate UMI in tag separated by delimiter
+    --cell-tag=CELL_TAG
+                        tag containing cell barcode
+    --cell-tag-split=CELL_TAG_SPLIT
+                        split cell barcode in tag and take the firstelement
+                        for e.g 10X GEM tags
+    --cell-tag-delimiter=CELL_TAG_DELIM
+                        concatenate cell barcode in tag separated by delimiter
+
+  UMI grouping options:
+    --method=METHOD     method to use for umi grouping [default=directional]
+    --edit-distance-threshold=THRESHOLD
+                        Edit distance theshold at which to join two UMIs when
+                        grouping UMIs. [default=1]
+    --spliced-is-unique
+                        Treat a spliced read as different to an unspliced one
+                        [default=False]
+    --soft-clip-threshold=SOFT_CLIP_THRESHOLD
+                        number of bases clipped from 5' end before read is
+                        counted as spliced [default=4]
+    --read-length       use read length in addition to position and UMI to
+                        identify possible duplicates [default=False]
+
+  single-cell RNA-Seq options:
+    --per-gene          Group/Dedup/Count per gene. Must combine with either
+                        --gene-tag or --per-contig
+    --gene-tag=GENE_TAG
+                        Gene is defined by this bam tag [default=none]
+    --assigned-status-tag=ASSIGNED_TAG
+                        Bam tag describing whether read is assigned to a gene
+                        By defualt, this is set as the same tag as --gene-tag
+    --skip-tags-regex=SKIP_REGEX
+                        Used with --gene-tag. Ignore reads where the gene-tag
+                        matches this regex
+    --per-contig        group/dedup/count UMIs per contig (field 3 in BAM;
+                        RNAME), e.g for transcriptome where contig = gene
+    --gene-transcript-map=GENE_TRANSCRIPT_MAP
+                        File mapping transcripts to genes (tab separated)
+    --per-cell          group/dedup/count per cell
+
+  SAM/BAM options:
+    --mapping-quality=MAPPING_QUALITY
+                        Minimum mapping quality for a read to be retained
+                        [default=0]
+    --unmapped-reads=UNMAPPED_READS
+                        How to handle unmapped reads. Options are 'discard',
+                        'use' or 'correct' [default=discard]
+    --chimeric-pairs=CHIMERIC_PAIRS
+                        How to handle chimeric read pairs. Options are
+                        'discard', 'use' or 'correct' [default=use]
+    --unpaired-reads=UNPAIRED_READS
+                        How to handle unpaired reads. Options are 'discard',
+                        'use' or 'correct' [default=use]
+    --ignore-umi        Ignore UMI and dedup only on position
+    --ignore-tlen       Option to dedup paired end reads based solely on
+                        read1, whether or not the template length is the same
+    --chrom=CHROM       Restrict to one chromosome
+    --subset=SUBSET     Use only a fraction of reads, specified by subset
+    -i, --in-sam        Input file is in sam format [default=False]
+    --paired            paired input BAM. [default=False]
+    -o, --out-sam       Output alignments in sam format [default=False]
+    --no-sort-output    Don't Sort the output
+
+  input/output options:
+    -I FILE, --stdin=FILE
+                        file to read stdin from [default = stdin].
+    -L FILE, --log=FILE
+                        file with logging information [default = stdout].
+    -E FILE, --error=FILE
+                        file with error information [default = stderr].
+    -S FILE, --stdout=FILE
+                        file where output is to go [default = stdout].
+    --temp-dir=FILE     Directory for temporary files. If not set, the bash
+                        environmental variable TMPDIR is used[default = None].
+    --log2stderr        send logging information to stderr [default = False].
+    --compresslevel=COMPRESSLEVEL
+                        Level of Gzip compression to use. Default (6)
+                        matchesGNU gzip rather than python gzip default (which
+                        is 9)
+
+  profiling options:
+    --timeit=TIMEIT_FILE
+                        store timeing information in file [none].
+    --timeit-name=TIMEIT_NAME
+                        name in timing file for this class of jobs [all].
+    --timeit-header     add header for timing information [none].
+
+  common options:
+    -v LOGLEVEL, --verbose=LOGLEVEL
+                        loglevel [1]. The higher, the more output.
+    -h, --help          output short help (command line options only).
+    --help-extended     Output full documentation
+    --random-seed=RANDOM_SEED
+                        random seed to initialize number generator with
+                        [none].

--- a/tests/count_tab_help
+++ b/tests/count_tab_help
@@ -1,0 +1,68 @@
+
+count_tab - Count reads per gene from flatfile using UMIs
+
+Usage: umi_tools count_tab [OPTIONS] [--stdin=IN_TSV[.gz]] [--stdout=OUT_TSV[.gz]]
+
+       note: If --stdin/--stdout are ommited standard in and standard
+             out are used for input and output. Input/Output will be
+             (de)compressed if a filename provided to --stdin/--stdout
+             ends in .gz 
+
+For full UMI-tools documentation, see https://umi-tools.readthedocs.io/en/latest/
+
+Options:
+  --version             show program's version number and exit
+
+  count_tab-specific options:
+    --barcode-separator=BC_SEP
+                        separator between read id and UMI  and (optionally)
+                        the cell barcode
+    --per-cell          Readname includes cell barcode as well as UMI in
+                        format: read[sep]UMI[sep]CB
+
+  UMI grouping options:
+    --method=METHOD     method to use for umi grouping [default=directional]
+    --edit-distance-threshold=THRESHOLD
+                        Edit distance theshold at which to join two UMIs when
+                        grouping UMIs. [default=1]
+    --spliced-is-unique
+                        Treat a spliced read as different to an unspliced one
+                        [default=False]
+    --soft-clip-threshold=SOFT_CLIP_THRESHOLD
+                        number of bases clipped from 5' end before read is
+                        counted as spliced [default=4]
+    --read-length       use read length in addition to position and UMI to
+                        identify possible duplicates [default=False]
+
+  input/output options:
+    -I FILE, --stdin=FILE
+                        file to read stdin from [default = stdin].
+    -L FILE, --log=FILE
+                        file with logging information [default = stdout].
+    -E FILE, --error=FILE
+                        file with error information [default = stderr].
+    -S FILE, --stdout=FILE
+                        file where output is to go [default = stdout].
+    --temp-dir=FILE     Directory for temporary files. If not set, the bash
+                        environmental variable TMPDIR is used[default = None].
+    --log2stderr        send logging information to stderr [default = False].
+    --compresslevel=COMPRESSLEVEL
+                        Level of Gzip compression to use. Default (6)
+                        matchesGNU gzip rather than python gzip default (which
+                        is 9)
+
+  profiling options:
+    --timeit=TIMEIT_FILE
+                        store timeing information in file [none].
+    --timeit-name=TIMEIT_NAME
+                        name in timing file for this class of jobs [all].
+    --timeit-header     add header for timing information [none].
+
+  common options:
+    -v LOGLEVEL, --verbose=LOGLEVEL
+                        loglevel [1]. The higher, the more output.
+    -h, --help          output short help (command line options only).
+    --help-extended     Output full documentation
+    --random-seed=RANDOM_SEED
+                        random seed to initialize number generator with
+                        [none].

--- a/tests/dedup_help
+++ b/tests/dedup_help
@@ -1,0 +1,134 @@
+
+dedup - Deduplicate reads using UMI and mapping coordinates
+
+Usage: umi_tools dedup [OPTIONS] [--stdin=IN_BAM] [--stdout=OUT_BAM]
+
+       note: If --stdout is ommited, standard out is output. To
+             generate a valid BAM file on standard out, please
+             redirect log with --log=LOGFILE or --log2stderr 
+
+For full UMI-tools documentation, see https://umi-tools.readthedocs.io/en/latest/
+
+Options:
+  --version             show program's version number and exit
+
+  dedup-specific options:
+    --output-stats=STATS
+                        Specify location to output stats
+
+  Barcode extraction options:
+    --extract-umi-method=GET_UMI_METHOD
+                        how is the read UMI +/ cell barcode encoded?
+                        [default=read_id]
+    --umi-separator=UMI_SEP
+                        separator between read id and UMI
+    --umi-tag=UMI_TAG   tag containing umi
+    --umi-tag-split=UMI_TAG_SPLIT
+                        split UMI in tag and take the first element
+    --umi-tag-delimiter=UMI_TAG_DELIM
+                        concatenate UMI in tag separated by delimiter
+    --cell-tag=CELL_TAG
+                        tag containing cell barcode
+    --cell-tag-split=CELL_TAG_SPLIT
+                        split cell barcode in tag and take the firstelement
+                        for e.g 10X GEM tags
+    --cell-tag-delimiter=CELL_TAG_DELIM
+                        concatenate cell barcode in tag separated by delimiter
+
+  UMI grouping options:
+    --method=METHOD     method to use for umi grouping [default=directional]
+    --edit-distance-threshold=THRESHOLD
+                        Edit distance theshold at which to join two UMIs when
+                        grouping UMIs. [default=1]
+    --spliced-is-unique
+                        Treat a spliced read as different to an unspliced one
+                        [default=False]
+    --soft-clip-threshold=SOFT_CLIP_THRESHOLD
+                        number of bases clipped from 5' end before read is
+                        counted as spliced [default=4]
+    --read-length       use read length in addition to position and UMI to
+                        identify possible duplicates [default=False]
+
+  single-cell RNA-Seq options:
+    --per-gene          Group/Dedup/Count per gene. Must combine with either
+                        --gene-tag or --per-contig
+    --gene-tag=GENE_TAG
+                        Gene is defined by this bam tag [default=none]
+    --assigned-status-tag=ASSIGNED_TAG
+                        Bam tag describing whether read is assigned to a gene
+                        By defualt, this is set as the same tag as --gene-tag
+    --skip-tags-regex=SKIP_REGEX
+                        Used with --gene-tag. Ignore reads where the gene-tag
+                        matches this regex
+    --per-contig        group/dedup/count UMIs per contig (field 3 in BAM;
+                        RNAME), e.g for transcriptome where contig = gene
+    --gene-transcript-map=GENE_TRANSCRIPT_MAP
+                        File mapping transcripts to genes (tab separated)
+    --per-cell          group/dedup/count per cell
+
+  group/dedup options:
+    --buffer-whole-contig
+                        Read whole contig before outputting bundles:
+                        guarantees that no reads are missed, but increases
+                        memory usage
+    --multimapping-detection-method=DETECTION_METHOD
+                        Some aligners identify multimapping using bam tags.
+                        Setting this option to NH, X0 or XT will use these
+                        tags when selecting the best read amongst reads with
+                        the same position and umi [default=none]
+
+  SAM/BAM options:
+    --mapping-quality=MAPPING_QUALITY
+                        Minimum mapping quality for a read to be retained
+                        [default=0]
+    --unmapped-reads=UNMAPPED_READS
+                        How to handle unmapped reads. Options are 'discard',
+                        'use' or 'correct' [default=discard]
+    --chimeric-pairs=CHIMERIC_PAIRS
+                        How to handle chimeric read pairs. Options are
+                        'discard', 'use' or 'correct' [default=use]
+    --unpaired-reads=UNPAIRED_READS
+                        How to handle unpaired reads. Options are 'discard',
+                        'use' or 'correct' [default=use]
+    --ignore-umi        Ignore UMI and dedup only on position
+    --ignore-tlen       Option to dedup paired end reads based solely on
+                        read1, whether or not the template length is the same
+    --chrom=CHROM       Restrict to one chromosome
+    --subset=SUBSET     Use only a fraction of reads, specified by subset
+    -i, --in-sam        Input file is in sam format [default=False]
+    --paired            paired input BAM. [default=False]
+    -o, --out-sam       Output alignments in sam format [default=False]
+    --no-sort-output    Don't Sort the output
+
+  input/output options:
+    -I FILE, --stdin=FILE
+                        file to read stdin from [default = stdin].
+    -L FILE, --log=FILE
+                        file with logging information [default = stdout].
+    -E FILE, --error=FILE
+                        file with error information [default = stderr].
+    -S FILE, --stdout=FILE
+                        file where output is to go [default = stdout].
+    --temp-dir=FILE     Directory for temporary files. If not set, the bash
+                        environmental variable TMPDIR is used[default = None].
+    --log2stderr        send logging information to stderr [default = False].
+    --compresslevel=COMPRESSLEVEL
+                        Level of Gzip compression to use. Default (6)
+                        matchesGNU gzip rather than python gzip default (which
+                        is 9)
+
+  profiling options:
+    --timeit=TIMEIT_FILE
+                        store timeing information in file [none].
+    --timeit-name=TIMEIT_NAME
+                        name in timing file for this class of jobs [all].
+    --timeit-header     add header for timing information [none].
+
+  common options:
+    -v LOGLEVEL, --verbose=LOGLEVEL
+                        loglevel [1]. The higher, the more output.
+    -h, --help          output short help (command line options only).
+    --help-extended     Output full documentation
+    --random-seed=RANDOM_SEED
+                        random seed to initialize number generator with
+                        [none].

--- a/tests/dedup_help.txt
+++ b/tests/dedup_help.txt
@@ -1,0 +1,135 @@
+UMI-Tools: Version 1.1.4
+
+dedup - Deduplicate reads using UMI and mapping coordinates
+
+Usage: umi_tools dedup [OPTIONS] [--stdin=IN_BAM] [--stdout=OUT_BAM]
+
+       note: If --stdout is ommited, standard out is output. To
+             generate a valid BAM file on standard out, please
+             redirect log with --log=LOGFILE or --log2stderr 
+
+For full UMI-tools documentation, see https://umi-tools.readthedocs.io/en/latest/
+
+Options:
+  --version             show program's version number and exit
+
+  dedup-specific options:
+    --output-stats=STATS
+                        Specify location to output stats
+
+  Barcode extraction options:
+    --extract-umi-method=GET_UMI_METHOD
+                        how is the read UMI +/ cell barcode encoded?
+                        [default=read_id]
+    --umi-separator=UMI_SEP
+                        separator between read id and UMI
+    --umi-tag=UMI_TAG   tag containing umi
+    --umi-tag-split=UMI_TAG_SPLIT
+                        split UMI in tag and take the first element
+    --umi-tag-delimiter=UMI_TAG_DELIM
+                        concatenate UMI in tag separated by delimiter
+    --cell-tag=CELL_TAG
+                        tag containing cell barcode
+    --cell-tag-split=CELL_TAG_SPLIT
+                        split cell barcode in tag and take the firstelement
+                        for e.g 10X GEM tags
+    --cell-tag-delimiter=CELL_TAG_DELIM
+                        concatenate cell barcode in tag separated by delimiter
+
+  UMI grouping options:
+    --method=METHOD     method to use for umi grouping [default=directional]
+    --edit-distance-threshold=THRESHOLD
+                        Edit distance theshold at which to join two UMIs when
+                        grouping UMIs. [default=1]
+    --spliced-is-unique
+                        Treat a spliced read as different to an unspliced one
+                        [default=False]
+    --soft-clip-threshold=SOFT_CLIP_THRESHOLD
+                        number of bases clipped from 5' end before read is
+                        counted as spliced [default=4]
+    --read-length       use read length in addition to position and UMI to
+                        identify possible duplicates [default=False]
+
+  single-cell RNA-Seq options:
+    --per-gene          Group/Dedup/Count per gene. Must combine with either
+                        --gene-tag or --per-contig
+    --gene-tag=GENE_TAG
+                        Gene is defined by this bam tag [default=none]
+    --assigned-status-tag=ASSIGNED_TAG
+                        Bam tag describing whether read is assigned to a gene
+                        By defualt, this is set as the same tag as --gene-tag
+    --skip-tags-regex=SKIP_REGEX
+                        Used with --gene-tag. Ignore reads where the gene-tag
+                        matches this regex
+    --per-contig        group/dedup/count UMIs per contig (field 3 in BAM;
+                        RNAME), e.g for transcriptome where contig = gene
+    --gene-transcript-map=GENE_TRANSCRIPT_MAP
+                        File mapping transcripts to genes (tab separated)
+    --per-cell          group/dedup/count per cell
+
+  group/dedup options:
+    --buffer-whole-contig
+                        Read whole contig before outputting bundles:
+                        guarantees that no reads are missed, but increases
+                        memory usage
+    --multimapping-detection-method=DETECTION_METHOD
+                        Some aligners identify multimapping using bam tags.
+                        Setting this option to NH, X0 or XT will use these
+                        tags when selecting the best read amongst reads with
+                        the same position and umi [default=none]
+
+  SAM/BAM options:
+    --mapping-quality=MAPPING_QUALITY
+                        Minimum mapping quality for a read to be retained
+                        [default=0]
+    --unmapped-reads=UNMAPPED_READS
+                        How to handle unmapped reads. Options are 'discard',
+                        'use' or 'correct' [default=discard]
+    --chimeric-pairs=CHIMERIC_PAIRS
+                        How to handle chimeric read pairs. Options are
+                        'discard', 'use' or 'correct' [default=use]
+    --unpaired-reads=UNPAIRED_READS
+                        How to handle unpaired reads. Options are 'discard',
+                        'use' or 'correct' [default=use]
+    --ignore-umi        Ignore UMI and dedup only on position
+    --ignore-tlen       Option to dedup paired end reads based solely on
+                        read1, whether or not the template length is the same
+    --chrom=CHROM       Restrict to one chromosome
+    --subset=SUBSET     Use only a fraction of reads, specified by subset
+    -i, --in-sam        Input file is in sam format [default=False]
+    --paired            paired input BAM. [default=False]
+    -o, --out-sam       Output alignments in sam format [default=False]
+    --no-sort-output    Don't Sort the output
+
+  input/output options:
+    -I FILE, --stdin=FILE
+                        file to read stdin from [default = stdin].
+    -L FILE, --log=FILE
+                        file with logging information [default = stdout].
+    -E FILE, --error=FILE
+                        file with error information [default = stderr].
+    -S FILE, --stdout=FILE
+                        file where output is to go [default = stdout].
+    --temp-dir=FILE     Directory for temporary files. If not set, the bash
+                        environmental variable TMPDIR is used[default = None].
+    --log2stderr        send logging information to stderr [default = False].
+    --compresslevel=COMPRESSLEVEL
+                        Level of Gzip compression to use. Default (6)
+                        matchesGNU gzip rather than python gzip default (which
+                        is 9)
+
+  profiling options:
+    --timeit=TIMEIT_FILE
+                        store timeing information in file [none].
+    --timeit-name=TIMEIT_NAME
+                        name in timing file for this class of jobs [all].
+    --timeit-header     add header for timing information [none].
+
+  common options:
+    -v LOGLEVEL, --verbose=LOGLEVEL
+                        loglevel [1]. The higher, the more output.
+    -h, --help          output short help (command line options only).
+    --help-extended     Output full documentation
+    --random-seed=RANDOM_SEED
+                        random seed to initialize number generator with
+                        [none].

--- a/tests/extract_help
+++ b/tests/extract_help
@@ -1,0 +1,112 @@
+
+extract - Extract UMI from fastq
+
+Usage:
+
+   Single-end:
+      umi_tools extract [OPTIONS] -p PATTERN [-I IN_FASTQ[.gz]] [-S OUT_FASTQ[.gz]]
+
+   Paired end:
+      umi_tools extract [OPTIONS] -p PATTERN [-I IN_FASTQ[.gz]] [-S OUT_FASTQ[.gz]] --read2-in=IN2_FASTQ[.gz] --read2-out=OUT2_FASTQ[.gz]
+
+   note: If -I/-S are ommited standard in and standard out are used
+         for input and output.  To generate a valid BAM file on
+         standard out, please redirect log with --log=LOGFILE or
+         --log2stderr. Input/Output will be (de)compressed if a
+         filename provided to -S/-I/--read2-in/read2-out ends in .gz
+         
+
+For full UMI-tools documentation, see https://umi-tools.readthedocs.io/en/latest/
+
+Options:
+  --version             show program's version number and exit
+
+  extract-specific options:
+    --read2-out=READ2_OUT
+                        file to output processed paired read to
+    --read2-stdout      Paired reads, send read2 to stdout, discarding read1
+    --quality-filter-threshold=QUALITY_FILTER_THRESHOLD
+                        Remove reads where any UMI base quality score falls
+                        below this threshold
+    --quality-filter-mask=QUALITY_FILTER_MASK
+                        If a UMI base has a quality below this threshold,
+                        replace the base with 'N'
+    --quality-encoding=QUALITY_ENCODING
+                        Quality score encoding. Choose from 'phred33'[33-77]
+                        'phred64' [64-106] or 'solexa' [59-106]
+    --error-correct-cell
+                        Correct errors in the cell barcode
+    --whitelist=WHITELIST
+                        A whitelist of accepted cell barcodes
+    --blacklist=BLACKLIST
+                        A blacklist of rejected cell barcodes
+    --subset-reads=READS_SUBSET, --reads-subset=READS_SUBSET
+                        Only extract from the first N reads. If N is greater
+                        than the number of reads, all reads will be used
+    --reconcile-pairs   Allow the presences of reads in read2 input that are
+                        not present in read1 input. This allows cell barcode
+                        filtering of read1s without considering read2s
+    --umi-separator=UMI_SEPARATOR
+                        Separator to use to add UMI to the read name. Default:
+                        _
+
+  [EXPERIMENTAl] barcode extraction options:
+    --either-read       UMI may be on either read (see --either-read-resolve)
+                        for options to resolve cases whereUMI is on both reads
+    --either-read-resolve=EITHER_READ_RESOLVE
+                        How to resolve instances where both reads contain a
+                        UMI but using --either-read.Choose from 'discard' or
+                        'quality'(use highest quality). default=dicard
+
+  fastq barcode extraction options:
+    --extract-method=EXTRACT_METHOD
+                        How to extract the umi +/- cell barcodes, Choose from
+                        'string' or 'regex'
+    -p PATTERN, --bc-pattern=PATTERN
+                        Barcode pattern
+    --bc-pattern2=PATTERN2
+                        Barcode pattern for paired reads
+    --3prime            barcode is on 3' end of read.
+    --read2-in=READ2_IN
+                        file name for read pairs
+    --filtered-out=FILTERED_OUT
+                        Write out reads not matching regex pattern to this
+                        file
+    --filtered-out2=FILTERED_OUT2
+                        Write out paired reads not matching regex pattern to
+                        this file
+    --ignore-read-pair-suffixes
+                        Ignore '\1' and '\2' read name suffixes
+
+  input/output options:
+    -I FILE, --stdin=FILE
+                        file to read stdin from [default = stdin].
+    -L FILE, --log=FILE
+                        file with logging information [default = stdout].
+    -E FILE, --error=FILE
+                        file with error information [default = stderr].
+    -S FILE, --stdout=FILE
+                        file where output is to go [default = stdout].
+    --temp-dir=FILE     Directory for temporary files. If not set, the bash
+                        environmental variable TMPDIR is used[default = None].
+    --log2stderr        send logging information to stderr [default = False].
+    --compresslevel=COMPRESSLEVEL
+                        Level of Gzip compression to use. Default (6)
+                        matchesGNU gzip rather than python gzip default (which
+                        is 9)
+
+  profiling options:
+    --timeit=TIMEIT_FILE
+                        store timeing information in file [none].
+    --timeit-name=TIMEIT_NAME
+                        name in timing file for this class of jobs [all].
+    --timeit-header     add header for timing information [none].
+
+  common options:
+    -v LOGLEVEL, --verbose=LOGLEVEL
+                        loglevel [1]. The higher, the more output.
+    -h, --help          output short help (command line options only).
+    --help-extended     Output full documentation
+    --random-seed=RANDOM_SEED
+                        random seed to initialize number generator with
+                        [none].

--- a/tests/group_help
+++ b/tests/group_help
@@ -1,0 +1,137 @@
+
+group - Group reads based on their UMI
+
+Usage: umi_tools group --output-bam [OPTIONS] [--stdin=INFILE.bam] [--stdout=OUTFILE.bam]
+
+       note: If --stdout is ommited, standard out is output. To
+             generate a valid BAM file on standard out, please
+             redirect log with --log=LOGFILE or --log2stderr 
+
+For full UMI-tools documentation, see https://umi-tools.readthedocs.io/en/latest/
+
+Options:
+  --version             show program's version number and exit
+  --umi-group-tag=UMI_GROUP_TAG
+                        tag for the outputted umi group
+
+  group-specific options:
+    --group-out=TSV     Outfile name for file mapping read id to read group
+    --output-bam        output a bam file with read groups tagged using the UG
+                        tag[default=False]
+
+  Barcode extraction options:
+    --extract-umi-method=GET_UMI_METHOD
+                        how is the read UMI +/ cell barcode encoded?
+                        [default=read_id]
+    --umi-separator=UMI_SEP
+                        separator between read id and UMI
+    --umi-tag=UMI_TAG   tag containing umi
+    --umi-tag-split=UMI_TAG_SPLIT
+                        split UMI in tag and take the first element
+    --umi-tag-delimiter=UMI_TAG_DELIM
+                        concatenate UMI in tag separated by delimiter
+    --cell-tag=CELL_TAG
+                        tag containing cell barcode
+    --cell-tag-split=CELL_TAG_SPLIT
+                        split cell barcode in tag and take the firstelement
+                        for e.g 10X GEM tags
+    --cell-tag-delimiter=CELL_TAG_DELIM
+                        concatenate cell barcode in tag separated by delimiter
+
+  UMI grouping options:
+    --method=METHOD     method to use for umi grouping [default=directional]
+    --edit-distance-threshold=THRESHOLD
+                        Edit distance theshold at which to join two UMIs when
+                        grouping UMIs. [default=1]
+    --spliced-is-unique
+                        Treat a spliced read as different to an unspliced one
+                        [default=False]
+    --soft-clip-threshold=SOFT_CLIP_THRESHOLD
+                        number of bases clipped from 5' end before read is
+                        counted as spliced [default=4]
+    --read-length       use read length in addition to position and UMI to
+                        identify possible duplicates [default=False]
+
+  single-cell RNA-Seq options:
+    --per-gene          Group/Dedup/Count per gene. Must combine with either
+                        --gene-tag or --per-contig
+    --gene-tag=GENE_TAG
+                        Gene is defined by this bam tag [default=none]
+    --assigned-status-tag=ASSIGNED_TAG
+                        Bam tag describing whether read is assigned to a gene
+                        By defualt, this is set as the same tag as --gene-tag
+    --skip-tags-regex=SKIP_REGEX
+                        Used with --gene-tag. Ignore reads where the gene-tag
+                        matches this regex
+    --per-contig        group/dedup/count UMIs per contig (field 3 in BAM;
+                        RNAME), e.g for transcriptome where contig = gene
+    --gene-transcript-map=GENE_TRANSCRIPT_MAP
+                        File mapping transcripts to genes (tab separated)
+    --per-cell          group/dedup/count per cell
+
+  group/dedup options:
+    --buffer-whole-contig
+                        Read whole contig before outputting bundles:
+                        guarantees that no reads are missed, but increases
+                        memory usage
+    --multimapping-detection-method=DETECTION_METHOD
+                        Some aligners identify multimapping using bam tags.
+                        Setting this option to NH, X0 or XT will use these
+                        tags when selecting the best read amongst reads with
+                        the same position and umi [default=none]
+
+  SAM/BAM options:
+    --mapping-quality=MAPPING_QUALITY
+                        Minimum mapping quality for a read to be retained
+                        [default=0]
+    --unmapped-reads=UNMAPPED_READS
+                        How to handle unmapped reads. Options are 'discard',
+                        'use' or 'correct' [default=discard]
+    --chimeric-pairs=CHIMERIC_PAIRS
+                        How to handle chimeric read pairs. Options are
+                        'discard', 'use' or 'correct' [default=use]
+    --unpaired-reads=UNPAIRED_READS
+                        How to handle unpaired reads. Options are 'discard',
+                        'use' or 'correct' [default=use]
+    --ignore-umi        Ignore UMI and dedup only on position
+    --ignore-tlen       Option to dedup paired end reads based solely on
+                        read1, whether or not the template length is the same
+    --chrom=CHROM       Restrict to one chromosome
+    --subset=SUBSET     Use only a fraction of reads, specified by subset
+    -i, --in-sam        Input file is in sam format [default=False]
+    --paired            paired input BAM. [default=False]
+    -o, --out-sam       Output alignments in sam format [default=False]
+    --no-sort-output    Don't Sort the output
+
+  input/output options:
+    -I FILE, --stdin=FILE
+                        file to read stdin from [default = stdin].
+    -L FILE, --log=FILE
+                        file with logging information [default = stdout].
+    -E FILE, --error=FILE
+                        file with error information [default = stderr].
+    -S FILE, --stdout=FILE
+                        file where output is to go [default = stdout].
+    --temp-dir=FILE     Directory for temporary files. If not set, the bash
+                        environmental variable TMPDIR is used[default = None].
+    --log2stderr        send logging information to stderr [default = False].
+    --compresslevel=COMPRESSLEVEL
+                        Level of Gzip compression to use. Default (6)
+                        matchesGNU gzip rather than python gzip default (which
+                        is 9)
+
+  profiling options:
+    --timeit=TIMEIT_FILE
+                        store timeing information in file [none].
+    --timeit-name=TIMEIT_NAME
+                        name in timing file for this class of jobs [all].
+    --timeit-header     add header for timing information [none].
+
+  common options:
+    -v LOGLEVEL, --verbose=LOGLEVEL
+                        loglevel [1]. The higher, the more output.
+    -h, --help          output short help (command line options only).
+    --help-extended     Output full documentation
+    --random-seed=RANDOM_SEED
+                        random seed to initialize number generator with
+                        [none].

--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -351,13 +351,6 @@ group_contig_no_gene_tag:
       references: [group_contig_no_gene_tag.tsv]
       options: group -L test.log --out-sam --per-contig --per-gene --random-seed=123456789 --method=directional --no-sort-output --output-bam --group-out=group_contig_no_gene_tag.tsv
 
-<<<<<<< Updated upstream
-dedup_help:
-      outputs: [stdout]
-      references: [dedup_help.txt]
-      options: dedup --help
-
-=======
 umi_tools_help:
       sort: False
       outputs: [stdout]
@@ -401,7 +394,6 @@ count_tab_help:
       options: count_tab --help
 
       
->>>>>>> Stashed changes
 # ### Tests to implement ####
 
 # ## dedup ##

--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -351,6 +351,11 @@ group_contig_no_gene_tag:
       references: [group_contig_no_gene_tag.tsv]
       options: group -L test.log --out-sam --per-contig --per-gene --random-seed=123456789 --method=directional --no-sort-output --output-bam --group-out=group_contig_no_gene_tag.tsv
 
+dedup_help:
+      outputs: [stdout]
+      references: [dedup_help.txt]
+      options: dedup --help
+
 # ### Tests to implement ####
 
 # ## dedup ##

--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -351,11 +351,57 @@ group_contig_no_gene_tag:
       references: [group_contig_no_gene_tag.tsv]
       options: group -L test.log --out-sam --per-contig --per-gene --random-seed=123456789 --method=directional --no-sort-output --output-bam --group-out=group_contig_no_gene_tag.tsv
 
+<<<<<<< Updated upstream
 dedup_help:
       outputs: [stdout]
       references: [dedup_help.txt]
       options: dedup --help
 
+=======
+umi_tools_help:
+      sort: False
+      outputs: [stdout]
+      references: [umi_tools_help]
+      options: --help
+
+whitelist_help:
+      sort: False
+      outputs: [stdout]
+      references: [whitelist_help]
+      options: whitelist --help
+
+extract_help:
+      sort: False
+      outputs: [stdout]
+      references: [extract_help]
+      options: extract --help
+
+dedup_help:
+      sort: False
+      outputs: [stdout]
+      references: [dedup_help]
+      options: dedup --help
+
+group_help:
+      sort: False
+      outputs: [stdout]
+      references: [group_help]
+      options: group --help
+
+count_help:
+      sort: False
+      outputs: [stdout]
+      references: [count_help]
+      options: count --help
+
+count_tab_help:
+      sort: False
+      outputs: [stdout]
+      references: [count_tab_help]
+      options: count_tab --help
+
+      
+>>>>>>> Stashed changes
 # ### Tests to implement ####
 
 # ## dedup ##

--- a/tests/umi_tools_help
+++ b/tests/umi_tools_help
@@ -1,0 +1,26 @@
+For full UMI-tools documentation, see: https://umi-tools.readthedocs.io/en/latest/
+
+
+umi_tools.py - Tools for UMI analyses
+=====================================
+
+:Author: Tom Smith & Ian Sudbury, CGAT
+:Tags: Genomics UMI
+
+There are 6 tools:
+
+  - whitelist
+  - extract
+  - group
+  - dedup
+  - count
+  - count_tab
+
+To get help on a specific tool, type:
+
+    umi_tools <tool> --help
+
+To use a specific tool, type::
+
+    umi_tools <tool> [tool options] [tool arguments]
+

--- a/tests/whitelist_help
+++ b/tests/whitelist_help
@@ -1,0 +1,102 @@
+
+whitelist - Generates a whitelist of accepted cell barcodes
+
+Usage:
+
+   Single-end:
+      umi_tools whitelist [OPTIONS] [-I IN_FASTQ[.gz]] [-S OUT_TSV[.gz]]
+
+   Paired end:
+      umi_tools whitelist [OPTIONS] [-I IN_FASTQ[.gz]] [-S OUT_TSV[.gz]] --read2-in=IN2_FASTQ[.gz]
+
+   note: If -I/-S are ommited standard in and standard out are used
+         for input and output.  Input/Output will be (de)compressed if a
+         filename provided to -S/-I/--read2-in ends in .gz
+
+
+For full UMI-tools documentation, see https://umi-tools.readthedocs.io/en/latest/
+
+Options:
+  --version             show program's version number and exit
+  --ed-above-threshold=ED_ABOVE_THRESHOLD
+                        Detect CBs above the threshold which may be sequence
+                        errors from another CB and either 'discard' or
+                        'correct'. Default=None (No correction)
+
+  whitelist-specific options:
+    --plot-prefix=PLOT_PREFIX
+                        Prefix for plots to visualise the automated detection
+                        of the number of 'true' cell barcodes
+    --subset-reads=SUBSET_READS
+                        Use the first N reads to automatically identify the
+                        true cell barcodes. If N is greater than the number of
+                        reads, all reads will be used. Default is 100,000,000
+    --error-correct-threshold=ERROR_CORRECT_THRESHOLD
+                        Hamming distance for correction of barcodes to
+                        whitelist barcodes. This value will also be used for
+                        error detection above the knee if required (--ed-
+                        above-threshold)
+    --method=METHOD     Use reads or unique umi counts per cell
+    --knee-method=KNEE_METHOD
+                        Use distance or density methods for detection of knee
+    --expect-cells=EXPECT_CELLS
+                        Prior expectation on the upper limit on the number of
+                        cells sequenced
+    --allow-threshold-error
+                        Don't select a threshold. Will still output the plots
+                        if requested (--plot-prefix)
+    --set-cell-number=CELL_NUMBER
+                        Specify the number of cell barcodes to accept
+
+  fastq barcode extraction options:
+    --extract-method=EXTRACT_METHOD
+                        How to extract the umi +/- cell barcodes, Choose from
+                        'string' or 'regex'
+    -p PATTERN, --bc-pattern=PATTERN
+                        Barcode pattern
+    --bc-pattern2=PATTERN2
+                        Barcode pattern for paired reads
+    --3prime            barcode is on 3' end of read.
+    --read2-in=READ2_IN
+                        file name for read pairs
+    --filtered-out=FILTERED_OUT
+                        Write out reads not matching regex pattern to this
+                        file
+    --filtered-out2=FILTERED_OUT2
+                        Write out paired reads not matching regex pattern to
+                        this file
+    --ignore-read-pair-suffixes
+                        Ignore '\1' and '\2' read name suffixes
+
+  input/output options:
+    -I FILE, --stdin=FILE
+                        file to read stdin from [default = stdin].
+    -L FILE, --log=FILE
+                        file with logging information [default = stdout].
+    -E FILE, --error=FILE
+                        file with error information [default = stderr].
+    -S FILE, --stdout=FILE
+                        file where output is to go [default = stdout].
+    --temp-dir=FILE     Directory for temporary files. If not set, the bash
+                        environmental variable TMPDIR is used[default = None].
+    --log2stderr        send logging information to stderr [default = False].
+    --compresslevel=COMPRESSLEVEL
+                        Level of Gzip compression to use. Default (6)
+                        matchesGNU gzip rather than python gzip default (which
+                        is 9)
+
+  profiling options:
+    --timeit=TIMEIT_FILE
+                        store timeing information in file [none].
+    --timeit-name=TIMEIT_NAME
+                        name in timing file for this class of jobs [all].
+    --timeit-header     add header for timing information [none].
+
+  common options:
+    -v LOGLEVEL, --verbose=LOGLEVEL
+                        loglevel [1]. The higher, the more output.
+    -h, --help          output short help (command line options only).
+    --help-extended     Output full documentation
+    --random-seed=RANDOM_SEED
+                        random seed to initialize number generator with
+                        [none].

--- a/umi_tools/umi_tools.py
+++ b/umi_tools/umi_tools.py
@@ -47,8 +47,6 @@ def main():
     elif len(argv) > 2 and  argv[2] in ["--help", "-h", "--help-extended"]:
         print("UMI-Tools: Version %s" % __version__)
 
-        return 0
-
     command = argv[1]
 
     try:

--- a/umi_tools/umi_tools.py
+++ b/umi_tools/umi_tools.py
@@ -44,9 +44,6 @@ def main():
 
         return 0
 
-    elif len(argv) > 2 and  argv[2] in ["--help", "-h", "--help-extended"]:
-        print("UMI-Tools: Version %s" % __version__)
-
     command = argv[1]
 
     try:


### PR DESCRIPTION
remove regression that caused umi_tools.py to quit before calling the command if --help was specified.

Added a test to test that there is help output from dedup. The reference will include the version number, which means this test will go out of date every time there is a version bump. On the other hand, should we test the help message from all tools?