### PR TITLE
Read suffixes removed from single end data

### DIFF
--- a/umi_tools/extract.py
+++ b/umi_tools/extract.py
@@ -373,7 +373,8 @@ def main(argv=None):
                         "(starting with 'cell_') %s, %s" % (
                             options.pattern, options.pattern2))
 
-    read1s = umi_methods.fastqIterate(options.stdin)
+    read1s = umi_methods.fastqIterate(options.stdin,
+                                      remove_suffix=options.ignore_suffix)
 
     # set up read extractor
     ReadExtractor = extract_methods.ExtractFilterAndUpdate(
@@ -458,7 +459,8 @@ def main(argv=None):
         if options.filtered_out2:
             filtered_out2 = U.openFile(options.filtered_out2, "w")
 
-        read2s = umi_methods.fastqIterate(U.openFile(options.read2_in))
+        read2s = umi_methods.fastqIterate(U.openFile(options.read2_in),
+                                          remove_suffix=options.ignore_suffix)
 
         if options.read2_out:
             read2_out = U.openFile(options.read2_out, "w")
@@ -469,7 +471,7 @@ def main(argv=None):
             strict = True
 
         for read1, read2 in umi_methods.joinedFastqIterate(
-                read1s, read2s, strict, options.ignore_suffix):
+                read1s, read2s, strict):
 
             # incrementing count for monitoring progress
             progCount += 1


### PR DESCRIPTION
Moved code to remove "suffixes" from the first word of of the read identifier from joinedFastqIterate to fastqIterate.

Changed call of fastqIterate in extract to specify  whether to remove suffixes.

Should solve #580 