### PR TITLE
change back to original matplotlib backend

### DIFF
--- a/umi_tools/whitelist_methods.py
+++ b/umi_tools/whitelist_methods.py
@@ -8,11 +8,11 @@ whitelist_methods.py - Methods for whitelisting cell barcodes
 import itertools
 import collections
 import matplotlib
+# change back to original user params after plotting
+_rcParams_orig = matplotlib.rcParams.copy()
 import copy
 import regex
 
-# require to run on systems with no X11
-matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 import matplotlib.lines as mlines
 
@@ -99,6 +99,9 @@ def getKneeEstimateDensity(cell_barcode_counts,
         final_barcodes = None
 
     if plotfile_prefix:
+
+        # require to run on systems with no X11
+        matplotlib.use('Agg')
 
         # colour-blind friendly colours - https://gist.github.com/thriveth/8560036
         CB_color_cycle = ['#377eb8', '#ff7f00', '#4daf4a',
@@ -243,6 +246,8 @@ def getKneeEstimateDensity(cell_barcode_counts,
                         threshold_type = "Rejected"
 
                     outf.write("%s\t%s\n" % (local_mins_count, threshold_type))
+
+        matplotlib.rcParams.update(_rcParams_orig)
 
     return final_barcodes
 

--- a/umi_tools/whitelist_methods.py
+++ b/umi_tools/whitelist_methods.py
@@ -8,8 +8,6 @@ whitelist_methods.py - Methods for whitelisting cell barcodes
 import itertools
 import collections
 import matplotlib
-# change back to original user params after plotting
-_rcParams_orig = matplotlib.rcParams.copy()
 import copy
 import regex
 
@@ -100,6 +98,8 @@ def getKneeEstimateDensity(cell_barcode_counts,
 
     if plotfile_prefix:
 
+        # change back to original user params after plotting
+        _rcParams_orig = matplotlib.rcParams.copy()
         # require to run on systems with no X11
         matplotlib.use('Agg')
 


### PR DESCRIPTION
When using the UMI-tools API only, I noticed it switches my Matplotlib backend to Agg, which messes with the plots I generate downstream. This PR changes the backend only when generating plots and then switches back to the user's original setting