### PR TITLE
Update _dedup_umi.pyx

### DIFF
--- a/umi_tools/_dedup_umi.pyx
+++ b/umi_tools/_dedup_umi.pyx
@@ -11,7 +11,7 @@ cpdef int edit_distance(a, b):
     # we only want to define hamming distances between barcodes with the same length 
     lb = len(b)
     if la != lb:
-        return np.Inf
+        return np.inf
 	    
     for k from 0 <= k < la:
         if aa[k] != bb[k]:


### PR DESCRIPTION
UMI_tools doesn't run on my linux with the following error:
AttributeError: `np.Inf` was removed in the NumPy 2.0 release. Use `np.inf` instead.

replacing np.Inf fixed the problem

