### PR TITLE
Updates python version tested

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         os: [ubuntu-latest]
 
     steps:


### PR DESCRIPTION
Tests for #677 failed:
`Error: The version '3.7' with architecture 'x64' was not found for Ubuntu 24.04.`

Since python 3.7 is no longer supported, seems reasonable to remove it from testing. Python 3.8 is also no longer supported 
as of Nov 2024 (https://www.python.org/downloads/), but it's available for the github action on latest Ubuntu, so I've left it in for now. I've also added py3.13.
