### PR TITLE
Strip fastq lines, rather than explicitly removing last char. 

### DIFF
--- a/umi_tools/umi_methods.py
+++ b/umi_tools/umi_methods.py
@@ -103,11 +103,11 @@ def fastqIterate(infile, remove_suffix=False):
             break
         if not line1.startswith('@'):
             U.error("parsing error: expected '@' in line %s" % line1)
-        line2 = convert2string(infile.readline())
-        line3 = convert2string(infile.readline())
+        line2 = convert2string(infile.readline()).rstrip()
+        line3 = convert2string(infile.readline()).rstrip()
         if not line3.startswith('+'):
             U.error("parsing error: expected '+' in line %s" % line3)
-        line4 = convert2string(infile.readline())
+        line4 = convert2string(infile.readline()).rstrip()
         # incomplete entry
         if not line4:
             U.error("incomplete entry for %s" % line1)
@@ -115,7 +115,7 @@ def fastqIterate(infile, remove_suffix=False):
         if remove_suffix:
             line1 = removeReadIDSuffix(line1)
             
-        yield Record(line1[1:], line2[:-1], line4[:-1])
+        yield Record(line1[1:], line2, line4)
 
 # End of FastqIterate()
 ###############################################################################


### PR DESCRIPTION
This should help if input file has DOS-like line endings, replacing them with UNIX ones.