### PR TITLE
{is} fix chimeric mates

### DIFF
--- a/umi_tools/sam_methods.py
+++ b/umi_tools/sam_methods.py
@@ -605,7 +605,7 @@ class TwoPassPairWriter:
             U.debug("Dumping %i mates for contig %s" % (
                 len(self.read1s), self.chrom))
 
-        for read in self.mate_file.fetch(reference=self.chrom, multiple_iterators=False):
+        for read in self.infile.fetch(reference=self.chrom, multiple_iterators=True):
             if any((read.is_unmapped, read.mate_is_unmapped, read.is_read1)):
                 continue
 
@@ -625,7 +625,7 @@ class TwoPassPairWriter:
                len(self.read1s))
 
         found = 0
-        for read in self.mate_file.fetch(until_eof=True, multiple_iterators=False):
+        for read in self.infile.fetch(until_eof=True, multiple_iterators=True):
 
             if any((read.is_unmapped, read.mate_is_unmapped, read.is_read1)):
                 continue

--- a/umi_tools/sam_methods.py
+++ b/umi_tools/sam_methods.py
@@ -605,7 +605,7 @@ class TwoPassPairWriter:
             U.debug("Dumping %i mates for contig %s" % (
                 len(self.read1s), self.chrom))
 
-        for read in self.infile.fetch(reference=self.chrom, multiple_iterators=True):
+        for read in self.mate_file.fetch(reference=self.chrom, multiple_iterators=False):
             if any((read.is_unmapped, read.mate_is_unmapped, read.is_read1)):
                 continue
 
@@ -625,7 +625,7 @@ class TwoPassPairWriter:
                len(self.read1s))
 
         found = 0
-        for read in self.infile.fetch(until_eof=True, multiple_iterators=True):
+        for read in self.mate_file.fetch(until_eof=True, multiple_iterators=True):
 
             if any((read.is_unmapped, read.mate_is_unmapped, read.is_read1)):
                 continue


### PR DESCRIPTION
Fixes #664 - reverts to using multiple iterators in the TwoPassWriter close method, but not write mates. This still saves the time from opening many iterators everything the contig is changed, but doesn't lose chimeric reads. 